### PR TITLE
VEGA-209: Setup repo for proof-of-concept apps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx
+COPY index.html /usr/share/nginx/html/index.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.6"
+
+services:
+  app:
+    build: .
+    ports: ["3784:80"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 version: "3.6"
 
 services:
+  api:
+    build: ./mock-api
+    ports: ["8081:8080"]
+
   app:
     build: .
-    ports: ["3784:80"]
+    ports: ["8080:80"]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1 @@
+<h1>Hello world!</h1>

--- a/index.html
+++ b/index.html
@@ -1,1 +1,10 @@
 <h1>Hello world!</h1>
+
+<script>
+fetch('http://localhost:8081/auth/change-password', {
+    mode: 'cors',
+    method: 'POST',
+    headers: new Headers({'Content-Type': 'application/x-www-form-urlencoded'}),
+    body: 'existingPassword=Password1&password=Password2&confirmPassword=Password2',
+})
+</script>

--- a/mock-api/Dockerfile
+++ b/mock-api/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.14
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN go get
+RUN go install
+
+CMD ["app"]

--- a/mock-api/main.go
+++ b/mock-api/main.go
@@ -2,30 +2,30 @@ package main
 
 import (
 	"encoding/json"
-    "log"
+	"log"
 	"net/http"
 
 	"github.com/gorilla/mux"
 )
 
 type Response struct {
-    Errors    string    `json:"errors"`
+	Errors string `json:"errors"`
 }
 
 func main() {
 
-    router := mux.NewRouter().StrictSlash(true)
+	router := mux.NewRouter().StrictSlash(true)
 	router.HandleFunc("/auth/change-password", ChangePassword).Methods(http.MethodPost, http.MethodOptions)
 	router.Use(mux.CORSMethodMiddleware(router))
 
-    log.Fatal(http.ListenAndServe(":8080", router))
+	log.Fatal(http.ListenAndServe(":8080", router))
 }
 
 func ChangePassword(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-    if r.Method == http.MethodOptions {
-        return
-    }
+	if r.Method == http.MethodOptions {
+		return
+	}
 
 	existingPassword := r.FormValue("existingPassword")
 	password := r.FormValue("password")
@@ -35,11 +35,11 @@ func ChangePassword(w http.ResponseWriter, r *http.Request) {
 
 	if existingPassword == "" || password == "" || confirmPassword == "" {
 		w.WriteHeader(http.StatusBadRequest)
-        errors = "Missing required field"
-    } else if (existingPassword != "Password1") {
+		errors = "Missing required field"
+	} else if existingPassword != "Password1" {
 		w.WriteHeader(http.StatusBadRequest)
 		errors = "Password supplied was incorrect or user is not active"
-	} else if (password != confirmPassword) {
+	} else if password != confirmPassword {
 		w.WriteHeader(http.StatusBadRequest)
 		errors = "Confirmation did not match new password"
 	}
@@ -47,6 +47,6 @@ func ChangePassword(w http.ResponseWriter, r *http.Request) {
 	response := Response{Errors: errors}
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-        panic(err)
-    }
+		panic(err)
+	}
 }

--- a/mock-api/main.go
+++ b/mock-api/main.go
@@ -46,7 +46,5 @@ func ChangePassword(w http.ResponseWriter, r *http.Request) {
 
 	response := Response{Errors: errors}
 
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		panic(err)
-	}
+	json.NewEncoder(w).Encode(response)
 }

--- a/mock-api/main.go
+++ b/mock-api/main.go
@@ -21,6 +21,18 @@ func main() {
 	log.Fatal(http.ListenAndServe(":8080", router))
 }
 
+func validate(existingPassword, password, confirmPassword string) (string, bool) {
+	if existingPassword == "" || password == "" || confirmPassword == "" {
+		return "Missing required field", false
+	} else if existingPassword != "Password1" {
+		return "Password supplied was incorrect or user is not active", false
+	} else if password != confirmPassword {
+		return "Confirmation did not match new password", false
+	}
+
+	return "", true
+}
+
 func ChangePassword(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	if r.Method == http.MethodOptions {
@@ -31,20 +43,11 @@ func ChangePassword(w http.ResponseWriter, r *http.Request) {
 	password := r.FormValue("password")
 	confirmPassword := r.FormValue("confirmPassword")
 
-	errors := ""
+	errorMessage, ok := validate(existingPassword, password, confirmPassword)
 
-	if existingPassword == "" || password == "" || confirmPassword == "" {
+	if !ok {
 		w.WriteHeader(http.StatusBadRequest)
-		errors = "Missing required field"
-	} else if existingPassword != "Password1" {
-		w.WriteHeader(http.StatusBadRequest)
-		errors = "Password supplied was incorrect or user is not active"
-	} else if password != confirmPassword {
-		w.WriteHeader(http.StatusBadRequest)
-		errors = "Confirmation did not match new password"
 	}
 
-	response := Response{Errors: errors}
-
-	json.NewEncoder(w).Encode(response)
+	json.NewEncoder(w).Encode(Response{Errors: errorMessage})
 }

--- a/mock-api/main.go
+++ b/mock-api/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+    "log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+type Response struct {
+    Errors    string    `json:"errors"`
+}
+
+func main() {
+
+    router := mux.NewRouter().StrictSlash(true)
+	router.HandleFunc("/auth/change-password", ChangePassword).Methods(http.MethodPost, http.MethodOptions)
+	router.Use(mux.CORSMethodMiddleware(router))
+
+    log.Fatal(http.ListenAndServe(":8080", router))
+}
+
+func ChangePassword(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+    if r.Method == http.MethodOptions {
+        return
+    }
+
+	existingPassword := r.FormValue("existingPassword")
+	password := r.FormValue("password")
+	confirmPassword := r.FormValue("confirmPassword")
+
+	errors := ""
+
+	if existingPassword == "" || password == "" || confirmPassword == "" {
+		w.WriteHeader(http.StatusBadRequest)
+        errors = "Missing required field"
+    } else if (existingPassword != "Password1") {
+		w.WriteHeader(http.StatusBadRequest)
+		errors = "Password supplied was incorrect or user is not active"
+	} else if (password != confirmPassword) {
+		w.WriteHeader(http.StatusBadRequest)
+		errors = "Confirmation did not match new password"
+	}
+
+	response := Response{Errors: errors}
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+        panic(err)
+    }
+}

--- a/mock-api/main.go
+++ b/mock-api/main.go
@@ -16,7 +16,6 @@ func main() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	router.HandleFunc("/auth/change-password", ChangePassword).Methods(http.MethodPost, http.MethodOptions)
-	router.Use(mux.CORSMethodMiddleware(router))
 
 	log.Fatal(http.ListenAndServe(":8080", router))
 }
@@ -35,6 +34,8 @@ func validate(existingPassword, password, confirmPassword string) (string, bool)
 
 func ChangePassword(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST,OPTIONS")
+
 	if r.Method == http.MethodOptions {
 		return
 	}


### PR DESCRIPTION
To demonstrate our proof-of-concept apps work in context, I've added the base code for two requirements:
- They must be built into the docker container `app` (the Dockerfile can be rewritten however you like)
- They must interact with the mock API

The mock API is written in Go and only supports `POST /auth/change-password`. It roughly emulates how the real endpoint works.