### PR TITLE
Don't use New Transport font

### DIFF
--- a/build_assets.sh
+++ b/build_assets.sh
@@ -8,8 +8,8 @@ npx sass --load-path=. web/assets/main.scss web/static/stylesheets/all.css
 mkdir -p web/static/javascript 
 npx webpack --mode production --entry ./web/assets/main.js --output web/static/javascript/all.js
 
-mkdir -p web/static/assets/fonts
-cp node_modules/govuk-frontend/govuk/assets/fonts/* web/static/assets/fonts
+# mkdir -p web/static/assets/font
+# cp node_modules/govuk-frontend/govuk/assets/fonts/* web/static/assets/fonts
 
 mkdir -p web/static/assets/images
 cp node_modules/govuk-frontend/govuk/assets/images/* web/static/assets/images


### PR DESCRIPTION
We're not allowed to use New Transport outside of the *.service.gov.uk domain. Until we move, we can just not load the fonts and the frontend will fallback to Arial.