### PR TITLE
Fix: Check permissions before giving access to change phone number

### DIFF
--- a/internal/server/edit_my_details.go
+++ b/internal/server/edit_my_details.go
@@ -44,7 +44,7 @@ func editMyDetails(logger *log.Logger, client EditMyDetailsClient, tmpl Template
 			return
 		}
 
-		if !hasPermission("user", "patch", myPermissions) {
+		if !myPermissions.HasPermission("user", "patch") {
 			http.Redirect(w, r, "/my-details", http.StatusFound)
 			return
 		}

--- a/internal/server/edit_my_details.go
+++ b/internal/server/edit_my_details.go
@@ -44,7 +44,7 @@ func editMyDetails(logger *log.Logger, client EditMyDetailsClient, tmpl Template
 			return
 		}
 
-		if hasPermission("user", "patch", myPermissions) == false {
+		if !hasPermission("user", "patch", myPermissions) {
 			http.Redirect(w, r, "/my-details", http.StatusFound)
 			return
 		}

--- a/internal/server/edit_my_details_test.go
+++ b/internal/server/edit_my_details_test.go
@@ -130,7 +130,7 @@ func TestGetEditMyDetailsNotPermitted(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest("GET", "", nil)
 
-	editMyDetails(nil, client, template, "http://sirius").ServeHTTP(w, r)
+	editMyDetails(nil, client, template, "/prefix", "http://sirius").ServeHTTP(w, r)
 
 	resp := w.Result()
 	assert.Equal(http.StatusFound, resp.StatusCode)

--- a/internal/server/health_check.go
+++ b/internal/server/health_check.go
@@ -1,0 +1,9 @@
+package server
+
+import (
+	"net/http"
+)
+
+func healthCheck() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+}

--- a/internal/server/my_details.go
+++ b/internal/server/my_details.go
@@ -32,7 +32,7 @@ type myDetailsVars struct {
 
 func hasPermission(group string, method string, list sirius.PermissionSet) bool {
 	for _, b := range list[group].Permissions {
-		if strings.ToLower(b) == strings.ToLower(method) {
+		if strings.EqualFold(b, method) {
 			return true
 		}
 	}

--- a/internal/server/my_details.go
+++ b/internal/server/my_details.go
@@ -46,19 +46,15 @@ func myDetails(logger *log.Logger, client MyDetailsClient, tmpl Template, sirius
 			return
 		}
 
-		CanEditPhoneNumber := true
+		canEditPhoneNumber, err := client.HasPermission(r.Context(), r.Cookies(), "user", "patch");
 
-		if ok, err := client.HasPermission(r.Context(), r.Cookies(), "user", "patch"); !ok {
-			if err == sirius.ErrUnauthorized {
-				http.Redirect(w, r, siriusURL+"/auth", http.StatusFound)
-				return
-			} else if err != nil {
-				logger.Println("myDetails:", err)
-				http.Error(w, "Could not connect to Sirius", http.StatusInternalServerError)
-				return
-			}
-
-			CanEditPhoneNumber = false
+		if err == sirius.ErrUnauthorized {
+			http.Redirect(w, r, siriusURL+"/auth", http.StatusFound)
+			return
+		} else if err != nil {
+			logger.Println("myDetails:", err)
+			http.Error(w, "Could not connect to Sirius", http.StatusInternalServerError)
+			return
 		}
 
 		vars := myDetailsVars{
@@ -69,7 +65,7 @@ func myDetails(logger *log.Logger, client MyDetailsClient, tmpl Template, sirius
 			Surname:            myDetails.Surname,
 			Email:              myDetails.Email,
 			PhoneNumber:        myDetails.PhoneNumber,
-			CanEditPhoneNumber: CanEditPhoneNumber,
+			CanEditPhoneNumber: canEditPhoneNumber,
 		}
 
 		for _, role := range myDetails.Roles {

--- a/internal/server/my_details.go
+++ b/internal/server/my_details.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 	"net/http"
-	"strings"
 
 	"github.com/ministryofjustice/opg-sirius-user-management/internal/sirius"
 )
@@ -28,15 +27,6 @@ type myDetailsVars struct {
 	Teams        []string
 
 	CanEditPhoneNumber bool
-}
-
-func hasPermission(group string, method string, list sirius.PermissionSet) bool {
-	for _, b := range list[group].Permissions {
-		if strings.EqualFold(b, method) {
-			return true
-		}
-	}
-	return false
 }
 
 func myDetails(logger *log.Logger, client MyDetailsClient, tmpl Template, siriusURL string) http.Handler {
@@ -74,7 +64,7 @@ func myDetails(logger *log.Logger, client MyDetailsClient, tmpl Template, sirius
 			Surname:            myDetails.Surname,
 			Email:              myDetails.Email,
 			PhoneNumber:        myDetails.PhoneNumber,
-			CanEditPhoneNumber: hasPermission("user", "patch", myPermissions),
+			CanEditPhoneNumber: myPermissions.HasPermission("user", "patch"),
 		}
 
 		for _, role := range myDetails.Roles {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,6 +20,7 @@ type Template interface {
 func New(logger *log.Logger, client Client, templates map[string]*template.Template, prefix, siriusURL, webDir string) http.Handler {
 	mux := http.NewServeMux()
 	mux.Handle("/", http.RedirectHandler(prefix+"/my-details", http.StatusFound))
+	mux.Handle("/health-check", healthCheck())
 	mux.Handle("/my-details", myDetails(logger, client, templates["my-details.gotmpl"], siriusURL))
 	mux.Handle("/my-details/edit", editMyDetails(logger, client, templates["edit-my-details.gotmpl"], prefix, siriusURL))
 	mux.Handle("/change-password", changePassword(logger, client, templates["change-password.gotmpl"], prefix, siriusURL))

--- a/internal/sirius/permissions.go
+++ b/internal/sirius/permissions.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 type PermissionGroup struct {
@@ -13,6 +14,15 @@ type PermissionGroup struct {
 }
 
 type PermissionSet map[string]PermissionGroup
+
+func (ps PermissionSet) HasPermission(group string, method string) bool {
+	for _, b := range ps[group].Permissions {
+		if strings.EqualFold(b, method) {
+			return true
+		}
+	}
+	return false
+}
 
 type myPermissions struct {
 	Data PermissionSet `json:"data"`

--- a/internal/sirius/permissions.go
+++ b/internal/sirius/permissions.go
@@ -1,0 +1,45 @@
+package sirius
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+)
+
+type PermissionGroup struct {
+	Permissions []string `json:"permissions"`
+}
+
+type PermissionSet map[string]PermissionGroup
+
+type MyPermissions struct {
+	Data PermissionSet `json:"data"`
+}
+
+func (c *Client) MyPermissions(ctx context.Context, cookies []*http.Cookie) (PermissionSet, error) {
+	var v MyPermissions
+
+	req, err := c.newRequest(ctx, http.MethodGet, "/api/permission", nil, cookies)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, ErrUnauthorized
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("returned non-2XX response: " + strconv.Itoa(resp.StatusCode))
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&v)
+	return v.Data, err
+}

--- a/internal/sirius/permissions.go
+++ b/internal/sirius/permissions.go
@@ -14,12 +14,12 @@ type PermissionGroup struct {
 
 type PermissionSet map[string]PermissionGroup
 
-type MyPermissions struct {
+type myPermissions struct {
 	Data PermissionSet `json:"data"`
 }
 
 func (c *Client) MyPermissions(ctx context.Context, cookies []*http.Cookie) (PermissionSet, error) {
-	var v MyPermissions
+	var v myPermissions
 
 	req, err := c.newRequest(ctx, http.MethodGet, "/api/permission", nil, cookies)
 	if err != nil {

--- a/internal/sirius/permissions.go
+++ b/internal/sirius/permissions.go
@@ -13,9 +13,9 @@ type PermissionGroup struct {
 	Permissions []string `json:"permissions"`
 }
 
-type PermissionSet map[string]PermissionGroup
+type permissionSet map[string]PermissionGroup
 
-func (ps PermissionSet) HasPermission(group string, method string) bool {
+func (ps permissionSet) HasPermission(group string, method string) bool {
 	for _, b := range ps[group].Permissions {
 		if strings.EqualFold(b, method) {
 			return true
@@ -25,7 +25,7 @@ func (ps PermissionSet) HasPermission(group string, method string) bool {
 }
 
 type myPermissions struct {
-	Data PermissionSet `json:"data"`
+	Data permissionSet `json:"data"`
 }
 
 func (c *Client) HasPermission(ctx context.Context, cookies []*http.Cookie, group string, method string) (bool, error) {

--- a/internal/sirius/permissions_test.go
+++ b/internal/sirius/permissions_test.go
@@ -1,0 +1,112 @@
+package sirius
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/pact-foundation/pact-go/dsl"
+	"github.com/stretchr/testify/assert"
+)
+
+type permissionsResponse struct {
+	Data *struct {
+		User *struct {
+			Permissions []string `json:"permissions" pact:"min=1,contents=GET|POST|PATCH"`
+		} `json:"user"`
+	} `json:"data"`
+}
+
+func TestPermissions(t *testing.T) {
+	pact := &dsl.Pact{
+		Consumer:          "sirius-user-management",
+		Provider:          "sirius",
+		Host:              "localhost",
+		PactFileWriteMode: "merge",
+		LogDir:            "../../logs",
+		PactDir:           "../../pacts",
+	}
+	defer pact.Teardown()
+
+	testCases := map[string]struct {
+		setup               func()
+		cookies             []*http.Cookie
+		expectedPermissions PermissionSet
+		expectedError       error
+	}{
+		"OK": {
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("User exists").
+					UponReceiving("A request to get my permissions").
+					WithRequest(dsl.Request{
+						Method: http.MethodGet,
+						Path:   dsl.String("/api/permission"),
+						Headers: dsl.MapMatcher{
+							"X-XSRF-TOKEN":        dsl.String("abcde"),
+							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
+							"OPG-Bypass-Membrane": dsl.String("1"),
+						},
+					}).
+					WillRespondWith(dsl.Response{
+						Status:  http.StatusOK,
+						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+						Body: dsl.Like(map[string]interface{}{
+							"data": map[string]interface{}{
+								"user": map[string]interface{}{
+									"permissions": dsl.EachLike("GET", 1),
+								},
+							},
+						}),
+					})
+			},
+			cookies: []*http.Cookie{
+				{Name: "XSRF-TOKEN", Value: "abcde"},
+				{Name: "Other", Value: "other"},
+			},
+			expectedPermissions: PermissionSet{
+				"user": {
+					Permissions: []string{
+						"GET",
+					},
+				},
+			},
+		},
+		"Unauthorized": {
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("User exists").
+					UponReceiving("A request to get my details without cookies").
+					WithRequest(dsl.Request{
+						Method: http.MethodGet,
+						Path:   dsl.String("/api/permission"),
+						Headers: dsl.MapMatcher{
+							"OPG-Bypass-Membrane": dsl.String("1"),
+						},
+					}).
+					WillRespondWith(dsl.Response{
+						Status: http.StatusUnauthorized,
+					})
+			},
+			expectedError: ErrUnauthorized,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tc.setup()
+
+			assert.Nil(t, pact.Verify(func() error {
+				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
+
+				permissions, err := client.MyPermissions(context.Background(), tc.cookies)
+				assert.Equal(t, tc.expectedPermissions, permissions)
+				assert.Equal(t, tc.expectedError, err)
+				return nil
+			}))
+		})
+	}
+}

--- a/internal/sirius/permissions_test.go
+++ b/internal/sirius/permissions_test.go
@@ -10,14 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type permissionsResponse struct {
-	Data *struct {
-		User *struct {
-			Permissions []string `json:"permissions" pact:"min=1,contents=GET|POST|PATCH"`
-		} `json:"user"`
-	} `json:"data"`
-}
-
 func TestPermissions(t *testing.T) {
 	pact := &dsl.Pact{
 		Consumer:          "sirius-user-management",

--- a/internal/sirius/permissions_test.go
+++ b/internal/sirius/permissions_test.go
@@ -107,7 +107,7 @@ func TestPermissions(t *testing.T) {
 	}
 }
 
-func TestpermissionSetChecksPermission(t *testing.T) {
+func TestPermissionSetChecksPermission(t *testing.T) {
 	permissions := permissionSet{
 		"user": {
 			Permissions: []string{"GET", "PATCH"},

--- a/internal/sirius/permissions_test.go
+++ b/internal/sirius/permissions_test.go
@@ -102,3 +102,18 @@ func TestPermissions(t *testing.T) {
 		})
 	}
 }
+
+func TestPermissionSetChecksPermission(t *testing.T) {
+	permissions := PermissionSet{
+		"user": {
+			Permissions: []string{"GET", "PATCH"},
+		},
+		"team": {
+			Permissions: []string{"GET"},
+		},
+	}
+
+	assert.True(t, permissions.HasPermission("user", "PATCH"))
+	assert.True(t, permissions.HasPermission("team", "GET"))
+	assert.False(t, permissions.HasPermission("team", "PATCHs"))
+}

--- a/web/template/my-details.gotmpl
+++ b/web/template/my-details.gotmpl
@@ -25,9 +25,11 @@
           <dt class="govuk-summary-list__key">Phone number</dt>
           <dd class="govuk-summary-list__value">{{ .PhoneNumber }}</dd>
           <dd class="govuk-summary-list__actions">
+            {{ if .CanEditPhoneNumber }}
               <a class="govuk-link" href="{{ prefix "/my-details/edit" }}">
                 Change<span class="govuk-visually-hidden"> phone number</span>
               </a>
+            {{ end }}
           </dd>
         </div>
       </dl>


### PR DESCRIPTION
Checks if a user has permission to change their phone number before giving them the option to do so.

A few things I want to tidy up:
- ~~Create a route-blocking middleware to cause 403s, rather than managing in-handler~~
  - Roles are generally used for authorization, not permissions, so middleware is heavy-handed
- Standardise client mocks to better handle multiple requests (e.g. `permissions { count, err, data }` rather than `permissionsCount, permissionsErr, permissionsData` etc.)
- Standardise API error handling?
- Move template permissions to map? (`can { editPhoneNumber: true } `)