### PR TITLE
Fix: Use small resources for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
   test:
     docker:
       - image: circleci/golang
+    resource_class: small
     steps:
       - checkout
       - run:
@@ -62,6 +63,7 @@ jobs:
   lint:
     docker:
       - image: circleci/golang
+    resource_class: small
     steps:
       - checkout
       - run:
@@ -76,6 +78,7 @@ jobs:
 
   push:
     executor: ecr/python
+    resource_class: small
     parameters:
       container_repo_url:
         type: string


### PR DESCRIPTION
They cost 5 credits per minute rather than the default 10 (medium), and we don't need the extra resource 💰