### PR TITLE
Move Heroku build stage to package.json

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: cd prototype && yarn install && node ./node_modules/gulp/bin/gulp generate-assets && node listen-on-port.js
+web: node listen-on-port.js

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node listen-on-port.js
+web: node prototype/listen-on-port.js

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "license": "MIT",
   "scripts": {
-    "build": "webpack"
+    "build": "webpack",
+    "heroku-postbuild": "cd prototype && yarn install && node ./node_modules/gulp/bin/gulp generate-assets"
   },
   "dependencies": {
     "@ministryofjustice/frontend": "^0.0.19-alpha",


### PR DESCRIPTION
We currently do Heroku build-and-deploy in the `Procfile` command. This is technically the deploy step, and Heroku enforces a 60 second timeout for something to listen on the port.

By specifying `heroku-postbuild` step, we can install dependencies and generate assets in the build step and not be caught out by timeout.