### PR TITLE
VEGA-267: Check permissions to edit a team's type

### DIFF
--- a/internal/server/edit_team_test.go
+++ b/internal/server/edit_team_test.go
@@ -411,6 +411,24 @@ func TestPostEditTeamRefDataError(t *testing.T) {
 	assert.Equal(0, template.count)
 }
 
+func TestPostEditTeamHasPermissionError(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockEditTeamClient{}
+	client.hasPermission.err = StatusError(http.StatusInternalServerError)
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("POST", "/teams/edit/123", nil)
+
+	err := editTeam(client, template, "http://sirius")(w, r)
+
+	assert.Equal(StatusError(http.StatusInternalServerError), err)
+
+	assert.Equal(0, client.editTeam.count)
+	assert.Equal(0, template.count)
+}
+
 func TestBadMethodEditTeam(t *testing.T) {
 	assert := assert.New(t)
 

--- a/internal/sirius/has_permission_test.go
+++ b/internal/sirius/has_permission_test.go
@@ -58,6 +58,9 @@ func TestPermissions(t *testing.T) {
 								"user": map[string]interface{}{
 									"permissions": dsl.EachLike("PATCH", 1),
 								},
+								"team": map[string]interface{}{
+									"permissions": dsl.EachLike("POST", 1),
+								},
 							},
 						}),
 					})

--- a/web/template/team-edit.gotmpl
+++ b/web/template/team-edit.gotmpl
@@ -47,7 +47,7 @@
 
             <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="f-service-conditional" name="service" type="radio" value="supervision" aria-controls="conditional-f-service-conditional" {{ if not (eq .Team.Type "") }}checked{{ end }}>
+                <input class="govuk-radios__input" id="f-service-conditional" name="service" type="radio" value="supervision" aria-controls="conditional-f-service-conditional" {{ if not (eq .Team.Type "") }}checked{{ end }} {{ if not .CanEditTeamType }}disabled{{ end }}>
                 <label class="govuk-label govuk-radios__label" for="f-service-conditional">
                   Supervision
                 </label>
@@ -58,7 +58,7 @@
                   <label class="govuk-label" for="f-teamType">
                     Supervision team type
                   </label>
-                  <select class="govuk-select {{ if .Errors.teamType }}govuk-select--error{{ end }}" id="f-teamType" name="supervision-type">
+                  <select class="govuk-select {{ if .Errors.teamType }}govuk-select--error{{ end }}" id="f-teamType" name="supervision-type" {{ if not .CanEditTeamType }}disabled{{ end }}>
                     {{ range .TeamTypeOptions }}
                       <option value="{{ .Handle }}" {{ if eq $.Team.Type .Handle }}selected{{ end }}>{{ .Label }}</option>
                     {{ end }}
@@ -67,7 +67,7 @@
               </div>
 
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="f-service-conditional-2" name="service" type="radio" value="lpa" {{ if eq .Team.Type "" }}checked{{ end }}>
+                <input class="govuk-radios__input" id="f-service-conditional-2" name="service" type="radio" value="lpa" {{ if eq .Team.Type "" }}checked{{ end }} {{ if not .CanEditTeamType }}disabled{{ end }}>
                 <label class="govuk-label govuk-radios__label" for="f-service-conditional-2">
                   LPA
                 </label>


### PR DESCRIPTION
Editing a team's type requires the post/team permission. Without it, the input fields are now disabled and POSTing the data will have no effect.