### PR TITLE
VEGA-236: Handle validation errors when adding a user

### DIFF
--- a/internal/server/add_team_member.go
+++ b/internal/server/add_team_member.go
@@ -65,6 +65,9 @@ func addTeamMember(client AddTeamMemberClient, tmpl Template, siriusURL string) 
 					},
 				}
 				w.WriteHeader(http.StatusBadRequest)
+			} else if verr, ok := err.(*sirius.ValidationError); ok {
+				vars.Errors = verr.Errors
+				w.WriteHeader(http.StatusBadRequest)
 			} else if err != nil {
 				return err
 			} else {


### PR DESCRIPTION
If the response to a user-adding request returns a validation error (e.g. 400 + error messages), the addTeamMember handler needs to pass it to the UI.