### PR TITLE
VEGA-289 Modify contracts to allow them to pass with Sirius

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ jobs:
           root: ./pacts
           paths:
             - sirius-user-management-sirius.json
+            - ignored-ignored.json
 
   lint:
     docker:
@@ -102,6 +103,7 @@ jobs:
           name: Retrieve pact
           command: |
             docker container create --name temp -v pacts_data:/root hello-world
+            docker cp ./pacts/ignored-ignored.json temp:/root/ignored-ignored.json
             docker cp ./pacts/sirius-user-management-sirius.json temp:/root/sirius-user-management-sirius.json
       - run:
           name: Run pa11y
@@ -127,6 +129,7 @@ jobs:
           name: Retrieve pact
           command: |
             docker container create --name temp -v pacts_data:/root hello-world
+            docker cp ./pacts/ignored-ignored.json temp:/root/ignored-ignored.json
             docker cp ./pacts/sirius-user-management-sirius.json temp:/root/sirius-user-management-sirius.json
       - run:
           name: Run cypress

--- a/cypress/integration/add_team.spec.js
+++ b/cypress/integration/add_team.spec.js
@@ -8,7 +8,7 @@ describe("Teams", () => {
     it("allows me to add a new team", () => {
         cy.get("#f-name").clear().type("New team");
         cy.contains("label[for=f-service-conditional]", "Supervision").click();
-        cy.get("#f-supervision-type").select("Complaints");
+        cy.get("#f-supervision-type").select("Allocations");
         cy.get("#f-phone").clear().type("0123045067");
         cy.get("button[type=submit]").click();
 

--- a/cypress/integration/edit_team.spec.js
+++ b/cypress/integration/edit_team.spec.js
@@ -16,7 +16,7 @@ describe("Edit a team", () => {
 
     it("allows me to change the team's details", () => {
         cy.get("#f-name").clear().type("Another team");
-        cy.get("#f-teamType").select("COMPLAINTS");
+        cy.get("#f-teamType").select("ALLOCATIONS");
         cy.get("#f-phoneNumber").clear().type("03573953");
         cy.get("#f-email").clear().type("other.team@opgtest.com");
         cy.get("button[type=submit]").click();

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -15,7 +15,7 @@ services:
     build: ./pact-stub
     ports: ["8080:8080"]
     environment:
-      PACT_PATH: ./pacts/sirius-user-management-sirius.json
+      PACT_DIR: ./pacts
       PORT: 8080
     volumes:
       - type: volume

--- a/docker/docker-compose.cypress.yml
+++ b/docker/docker-compose.cypress.yml
@@ -13,7 +13,7 @@ services:
   pact-stub:
     build: ./pact-stub
     environment:
-      PACT_PATH: ./pacts/sirius-user-management-sirius.json
+      PACT_DIR: ./pacts
       PORT: 8080
     volumes:
       - "../pacts:/app/pacts"

--- a/docker/pact-stub/pact_stub.go
+++ b/docker/pact-stub/pact_stub.go
@@ -8,34 +8,48 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
 func main() {
 	port := os.Getenv("PORT")
-	pactPath := os.Getenv("PACT_PATH")
+	pactDir := os.Getenv("PACT_DIR")
 
-	pacts, err := readPacts(pactPath)
+	interactions, err := readInteractions(pactDir)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	if err := http.ListenAndServe(":"+port, &Server{interactions: pacts.Interactions}); err != nil {
+	if err := http.ListenAndServe(":"+port, &Server{interactions: interactions}); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func readPacts(path string) (Pacts, error) {
-	file, err := os.Open(path)
+func readInteractions(dir string) ([]Interaction, error) {
+	var interactions []Interaction
+
+	paths, err := filepath.Glob(dir + "/*.json")
 	if err != nil {
-		return Pacts{}, fmt.Errorf("opening %s: %w", path, err)
+		return nil, err
 	}
-	defer file.Close()
 
-	var v Pacts
-	err = json.NewDecoder(file).Decode(&v)
+	for _, path := range paths {
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("opening %s: %w", path, err)
+		}
+		defer file.Close()
 
-	return v, err
+		var v Pacts
+		if err = json.NewDecoder(file).Decode(&v); err != nil {
+			return nil, err
+		}
+
+		interactions = append(interactions, v.Interactions...)
+	}
+
+	return interactions, err
 }
 
 type Pacts struct {

--- a/internal/sirius/add_team_test.go
+++ b/internal/sirius/add_team_test.go
@@ -48,7 +48,7 @@ func TestAddTeam(t *testing.T) {
 							"OPG-Bypass-Membrane": dsl.String("1"),
 							"Content-Type":        dsl.String("application/x-www-form-urlencoded"),
 						},
-						Body: "email=a&name=b&phone=c&type=&teamType=",
+						Body: "email=john.doe@example.com&name=testteam&phone=0300456090&type=&teamType=",
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusCreated,
@@ -63,9 +63,9 @@ func TestAddTeam(t *testing.T) {
 				{Name: "XSRF-TOKEN", Value: "abcde"},
 				{Name: "Other", Value: "other"},
 			},
-			email:         "a",
-			name:          "b",
-			phone:         "c",
+			email:         "john.doe@example.com",
+			name:          "testteam",
+			phone:         "0300456090",
 			teamType:      "",
 			expectedID:    123,
 			expectedError: func(port int) error { return nil },
@@ -87,7 +87,7 @@ func TestAddTeam(t *testing.T) {
 							"OPG-Bypass-Membrane": dsl.String("1"),
 							"Content-Type":        dsl.String("application/x-www-form-urlencoded"),
 						},
-						Body: "email=a&name=b&phone=c&type=&teamType=&teamType[handle]=WHAT",
+						Body: "email=john.doe@example.com&name=supervisiontestteam&phone=0300456090&type=&teamType=&teamType[handle]=INVESTIGATIONS",
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusCreated,
@@ -102,10 +102,10 @@ func TestAddTeam(t *testing.T) {
 				{Name: "XSRF-TOKEN", Value: "abcde"},
 				{Name: "Other", Value: "other"},
 			},
-			email:         "a",
-			name:          "b",
-			phone:         "c",
-			teamType:      "WHAT",
+			email:         "john.doe@example.com",
+			name:          "supervisiontestteam",
+			phone:         "0300456090",
+			teamType:      "INVESTIGATIONS",
 			expectedID:    123,
 			expectedError: func(port int) error { return nil },
 		},
@@ -142,8 +142,12 @@ func TestAddTeam(t *testing.T) {
 						Method: http.MethodPost,
 						Path:   dsl.String("/api/team"),
 						Headers: dsl.MapMatcher{
+							"X-XSRF-TOKEN":        dsl.String("abcde"),
+							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
 							"OPG-Bypass-Membrane": dsl.String("1"),
+							"Content-Type":        dsl.String("application/x-www-form-urlencoded"),
 						},
+						Body: "email=john.doehrfgjuerhujghejrhrgherjrghgjrehergeghrjkrghkerhgerjkhgerjkheghergkhgekrhgerherhjghkjerhgherghjkerhgekjherkjhgerhgjehherkjhgkjehrghrehgkjrehjkghrjkehgrehehgkjhrejghhehgkjerhegjrhegrjhrjkhgkrhrghrkjegrkjehrghjkerhgjkhergjhrjkerregjhrekjhrgrehjkg@example.com&name=testteam&phone=0300456090&type=&teamType=",
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusBadRequest,
@@ -151,18 +155,26 @@ func TestAddTeam(t *testing.T) {
 							"data": dsl.Like(map[string]interface{}{
 								"errorMessages": dsl.Like(map[string]interface{}{
 									"email": dsl.Like(map[string]interface{}{
-										"stringLengthTooLong": "The input is more than 255 characters long",
+										"emailAddressLengthExceeded": "The input is more than 255 characters long",
 									}),
 								}),
 							}),
 						}),
 					})
 			},
+			cookies: []*http.Cookie{
+				{Name: "XSRF-TOKEN", Value: "abcde"},
+				{Name: "Other", Value: "other"},
+			},
+			email:    "john.doehrfgjuerhujghejrhrgherjrghgjrehergeghrjkrghkerhgerjkhgerjkheghergkhgekrhgerherhjghkjerhgherghjkerhgekjherkjhgerhgjehherkjhgkjehrghrehgkjrehjkghrjkehgrehehgkjhrejghhehgkjerhegjrhegrjhrjkhgkrhrghrkjegrkjehrghjkerhgjkhergjhrjkerregjhrekjhrgrehjkg@example.com",
+			name:     "testteam",
+			phone:    "0300456090",
+			teamType: "",
 			expectedError: func(_ int) error {
 				return ValidationError{
 					Errors: ValidationErrors{
 						"email": {
-							"stringLengthTooLong": "The input is more than 255 characters long",
+							"emailAddressLengthExceeded": "The input is more than 255 characters long",
 						},
 					},
 				}

--- a/internal/sirius/add_user_test.go
+++ b/internal/sirius/add_user_test.go
@@ -13,7 +13,7 @@ import (
 type addUserBadRequestResponse struct {
 	ErrorMessages *struct {
 		Email *struct {
-			StringLengthTooLong string `json:"stringLengthTooLong" pact:"example=The input is more than 255 characters long"`
+			EmailAddressLengthExceeded string `json:"emailAddressLengthExceeded" pact:"example=The input is more than 255 characters long"`
 		} `json:"email"`
 	} `json:"errorMessages"`
 }
@@ -110,7 +110,16 @@ func TestAddUser(t *testing.T) {
 						Method: http.MethodPost,
 						Path:   dsl.String("/auth/user"),
 						Headers: dsl.MapMatcher{
+							"X-XSRF-TOKEN":        dsl.String("abcde"),
+							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
 							"OPG-Bypass-Membrane": dsl.String("1"),
+							"Content-Type":        dsl.String("application/json"),
+						},
+						Body: map[string]interface{}{
+							"firstname": "John",
+							"surname":   "Doe",
+							"email":     "john.doefkhjgerhergjgerjkrgejgerjgerjegrjhkgrehjergjgerhjkgerhjkegrhjkgerhjkegrhjkegrhjkegrhjkgerhjkgerhjkgerhjkgerhjkgerhjkgerhjkegrhjkgerhjkgerhjkgerhjkgerhjkerghjkgerhjkgerhjkgerhjkgrhjkgrehjgerhjkgerhjkegrhjkgerhjkgrerghger@example.com",
+							"roles":     []string{"COP User", "other1", "other2"},
 						},
 					}).
 					WillRespondWith(dsl.Response{
@@ -118,10 +127,19 @@ func TestAddUser(t *testing.T) {
 						Body:   dsl.Match(addUserBadRequestResponse{}),
 					})
 			},
+			cookies: []*http.Cookie{
+				{Name: "XSRF-TOKEN", Value: "abcde"},
+				{Name: "Other", Value: "other"},
+			},
+			firstName:    "John",
+			lastName:     "Doe",
+			email:        "john.doefkhjgerhergjgerjkrgejgerjgerjegrjhkgrehjergjgerhjkgerhjkegrhjkgerhjkegrhjkegrhjkegrhjkgerhjkgerhjkgerhjkgerhjkgerhjkgerhjkegrhjkgerhjkgerhjkgerhjkgerhjkerghjkgerhjkgerhjkgerhjkgrhjkgrehjgerhjkgerhjkegrhjkgerhjkgrerghger@example.com",
+			organisation: "COP User",
+			roles:        []string{"other1", "other2"},
 			expectedError: ValidationError{
 				Errors: ValidationErrors{
 					"email": {
-						"stringLengthTooLong": "The input is more than 255 characters long",
+						"emailAddressLengthExceeded": "The input is more than 255 characters long",
 					},
 				},
 			},

--- a/internal/sirius/edit_my_details_test.go
+++ b/internal/sirius/edit_my_details_test.go
@@ -62,22 +62,6 @@ func TestEditMyDetails(t *testing.T) {
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
-						Body: dsl.Like(map[string]interface{}{
-							"id":          dsl.Like(47),
-							"name":        dsl.Like("system"),
-							"phoneNumber": dsl.Like("03004560300"),
-							"teams": dsl.EachLike(map[string]interface{}{
-								"displayName": dsl.Like("Allocations - (Supervision)"),
-							}, 1),
-							"displayName": dsl.Like("system admin"),
-							"deleted":     dsl.Like(false),
-							"email":       dsl.Like("system.admin@opgtest.com"),
-							"firstname":   dsl.Like("system"),
-							"surname":     dsl.Like("admin"),
-							"roles":       dsl.EachLike("System Admin", 1),
-							"locked":      dsl.Like(false),
-							"suspended":   dsl.Like(false),
-						}),
 					})
 			},
 			cookies: []*http.Cookie{
@@ -88,7 +72,7 @@ func TestEditMyDetails(t *testing.T) {
 
 		{
 			name:        "BadRequest",
-			phoneNumber: "invalid phone number",
+			phoneNumber: "85845984598649858684596849859549684568465894689498468495689645468384938743893892317571934751439574638753683761084565480713465618457365784613876481376457651471645463178546357843615971435645387364139756147361456145161587165477143576698764574569834659465974657946574569856896745229786",
 			setup: func() {
 				pact.
 					AddInteraction().
@@ -103,7 +87,7 @@ func TestEditMyDetails(t *testing.T) {
 							"OPG-Bypass-Membrane": dsl.String("1"),
 						},
 						Body: map[string]string{
-							"phoneNumber": "invalid phone number",
+							"phoneNumber": "85845984598649858684596849859549684568465894689498468495689645468384938743893892317571934751439574638753683761084565480713465618457365784613876481376457651471645463178546357843615971435645387364139756147361456145161587165477143576698764574569834659465974657946574569856896745229786",
 						},
 					}).
 					WillRespondWith(dsl.Response{

--- a/internal/sirius/edit_team_test.go
+++ b/internal/sirius/edit_team_test.go
@@ -14,7 +14,7 @@ type editTeamErrorsResponse struct {
 	Data *struct {
 		Errors *struct {
 			TeamType *struct {
-				InvalidTeamType string `json:"invalidTeamType" pact:"example=Invalid team type"`
+				TeamTypeAlreadyInUse string `json:"teamTypeAlreadyInUse" pact:"example=Invalid team type"`
 			} `json:"teamType"`
 		} `json:"errorMessages"`
 	} `json:"data"`
@@ -43,7 +43,7 @@ func TestEditTeam(t *testing.T) {
 			team: Team{
 				ID:          65,
 				DisplayName: "Test team",
-				Type:        "FINANCE",
+				Type:        "INVESTIGATIONS",
 				PhoneNumber: "014729583920",
 				Email:       "test.team@opgtest.com",
 			},
@@ -61,7 +61,7 @@ func TestEditTeam(t *testing.T) {
 							"OPG-Bypass-Membrane": dsl.String("1"),
 							"Content-Type":        dsl.String("application/x-www-form-urlencoded"),
 						},
-						Body: "email=test.team%40opgtest.com&name=Test+team&phoneNumber=014729583920&teamType%5Bhandle%5D=FINANCE",
+						Body: "email=test.team%40opgtest.com&name=Test+team&phoneNumber=014729583920&teamType%5Bhandle%5D=INVESTIGATIONS",
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -79,7 +79,7 @@ func TestEditTeam(t *testing.T) {
 			team: Team{
 				ID:          65,
 				DisplayName: "Test team",
-				Type:        "FINANCE",
+				Type:        "INVESTIGATIONS",
 				PhoneNumber: "014729583920",
 				Email:       "test.team@opgtest.com",
 				Members: []TeamMember{
@@ -106,7 +106,7 @@ func TestEditTeam(t *testing.T) {
 							"OPG-Bypass-Membrane": dsl.String("1"),
 							"Content-Type":        dsl.String("application/x-www-form-urlencoded"),
 						},
-						Body: "email=test.team%40opgtest.com&members%5B0%5D%5Bid%5D=23&members%5B1%5D%5Bid%5D=87&name=Test+team&phoneNumber=014729583920&teamType%5Bhandle%5D=FINANCE",
+						Body: "email=test.team%40opgtest.com&members%5B0%5D%5Bid%5D=23&members%5B1%5D%5Bid%5D=87&name=Test+team&phoneNumber=014729583920&teamType%5Bhandle%5D=INVESTIGATIONS",
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -151,13 +151,13 @@ func TestEditTeam(t *testing.T) {
 			team: Team{
 				ID:          65,
 				DisplayName: "Test team",
-				Type:        "BAD_TYPE",
+				Type:        "FINANCE",
 			},
 			setup: func() {
 				pact.
 					AddInteraction().
 					Given("A user and a team").
-					UponReceiving("A request to edit the team with an invalid type").
+					UponReceiving("A request to edit the team with an non-unique type").
 					WithRequest(dsl.Request{
 						Method: http.MethodPut,
 						Path:   dsl.String("/api/team/65"),
@@ -167,7 +167,7 @@ func TestEditTeam(t *testing.T) {
 							"OPG-Bypass-Membrane": dsl.String("1"),
 							"Content-Type":        dsl.String("application/x-www-form-urlencoded"),
 						},
-						Body: "email=&name=Test+team&phoneNumber=&teamType%5Bhandle%5D=BAD_TYPE",
+						Body: "email=&name=Test+team&phoneNumber=&teamType%5Bhandle%5D=FINANCE",
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusBadRequest,
@@ -182,7 +182,7 @@ func TestEditTeam(t *testing.T) {
 				return &ValidationError{
 					Errors: ValidationErrors{
 						"teamType": {
-							"invalidTeamType": "Invalid team type",
+							"teamTypeAlreadyInUse": "Invalid team type",
 						},
 					},
 				}

--- a/internal/sirius/team_test.go
+++ b/internal/sirius/team_test.go
@@ -35,7 +35,7 @@ func TestTeam(t *testing.T) {
 			setup: func() {
 				pact.
 					AddInteraction().
-					Given("User exists and supervision team exists").
+					Given("Supervision team with members exists").
 					UponReceiving("A request for a team").
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
@@ -91,7 +91,7 @@ func TestTeam(t *testing.T) {
 			setup: func() {
 				pact.
 					AddInteraction().
-					Given("User exists and LPA team exists").
+					Given("LPA team with members exists").
 					UponReceiving("A request for an LPA team").
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,

--- a/internal/sirius/team_types_test.go
+++ b/internal/sirius/team_types_test.go
@@ -50,20 +50,10 @@ func TestTeamTypes(t *testing.T) {
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
 						Body: dsl.Like(map[string]interface{}{
-							"teamType": []map[string]interface{}{
-								{
-									"handle": dsl.String("ALLOCATIONS"),
-									"label":  dsl.String("Allocations"),
-								},
-								{
-									"handle": dsl.String("COMPLAINTS"),
-									"label":  dsl.String("Complaints"),
-								},
-								{
-									"handle": dsl.String("INVESTIGATIONS"),
-									"label":  dsl.String("Investigations"),
-								},
-							},
+							"teamType": dsl.EachLike(map[string]interface{}{
+								"handle": dsl.String("ALLOCATIONS"),
+								"label":  dsl.String("Allocations"),
+							}, 1),
 						}),
 					})
 			},
@@ -75,14 +65,6 @@ func TestTeamTypes(t *testing.T) {
 				{
 					Handle: "ALLOCATIONS",
 					Label:  "Allocations",
-				},
-				{
-					Handle: "COMPLAINTS",
-					Label:  "Complaints",
-				},
-				{
-					Handle: "INVESTIGATIONS",
-					Label:  "Investigations",
 				},
 			},
 		},

--- a/internal/sirius/teams_test.go
+++ b/internal/sirius/teams_test.go
@@ -29,6 +29,66 @@ func TestTeams(t *testing.T) {
 		expectedError    error
 	}{
 		{
+			name: "Unauthorized",
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("User exists").
+					UponReceiving("A request for teams without cookies").
+					WithRequest(dsl.Request{
+						Method: http.MethodGet,
+						Path:   dsl.String("/api/v1/teams"),
+						Headers: dsl.MapMatcher{
+							"OPG-Bypass-Membrane": dsl.String("1"),
+						},
+					}).
+					WillRespondWith(dsl.Response{
+						Status: http.StatusUnauthorized,
+					})
+			},
+			expectedError: ErrUnauthorized,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+
+			assert.Nil(t, pact.Verify(func() error {
+				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
+
+				users, err := client.Teams(context.Background(), tc.cookies)
+				assert.Equal(t, tc.expectedResponse, users)
+				assert.Equal(t, tc.expectedError, err)
+				return nil
+			}))
+		})
+	}
+}
+
+func TestTeamsIgnoredPact(t *testing.T) {
+	// These tests are pretty much impossible to validate in Sirius due to the
+	// responses containing a mix of LPA and Supervision teams, and Pact not
+	// having a way to match arrays containing either type. We still want to
+	// produce a contract that can be used for mocking responses though.
+	pact := &dsl.Pact{
+		Consumer:          "ignored",
+		Provider:          "ignored",
+		Host:              "localhost",
+		PactFileWriteMode: "merge",
+		LogDir:            "../../logs",
+		PactDir:           "../../pacts",
+	}
+	defer pact.Teardown()
+
+	testCases := []struct {
+		name             string
+		setup            func()
+		cookies          []*http.Cookie
+		expectedResponse []Team
+		expectedError    error
+	}{
+		{
 			name: "OK",
 			setup: func() {
 				pact.
@@ -128,27 +188,6 @@ func TestTeams(t *testing.T) {
 					TypeLabel: "LPA",
 				},
 			},
-		},
-
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("User exists").
-					UponReceiving("A request for teams without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/api/v1/teams"),
-						Headers: dsl.MapMatcher{
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: ErrUnauthorized,
 		},
 	}
 


### PR DESCRIPTION
Verifying the "teams" interactions on Sirius is difficult so I've decided to split them out to a separate contract that we can still use for mocking, but won't get published. 