### PR TITLE
VEGA-289 Clean up tests

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -32,7 +32,7 @@ type Template interface {
 	ExecuteTemplate(io.Writer, string, interface{}) error
 }
 
-func New(logger Logger, client Client, templates map[string]*template.Template, prefix, siriusURL, siriusPublicURL string, webDir string) http.Handler {
+func New(logger Logger, client Client, templates map[string]*template.Template, prefix, siriusURL, siriusPublicURL, webDir string) http.Handler {
 	wrap := errorHandler(logger, templates["error.gotmpl"], prefix, siriusPublicURL)
 	systemAdminOnly := allowRoles(client, "System Admin")
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -36,6 +36,10 @@ func (m *mockTemplate) ExecuteTemplate(w io.Writer, name string, vars interface{
 	return nil
 }
 
+func TestNew(t *testing.T) {
+	assert.Implements(t, (*http.Handler)(nil), New(nil, nil, nil, "", "", "", ""))
+}
+
 func TestErrorHandler(t *testing.T) {
 	assert := assert.New(t)
 

--- a/internal/sirius/add_team.go
+++ b/internal/sirius/add_team.go
@@ -3,7 +3,6 @@ package sirius
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -45,16 +44,11 @@ func (c *Client) AddTeam(ctx context.Context, cookies []*http.Cookie, name, team
 			} `json:"data"`
 		}
 
-		err = json.NewDecoder(resp.Body).Decode(&v)
-		if err == nil {
+		if err := json.NewDecoder(resp.Body).Decode(&v); err == nil {
 			return 0, ValidationError{Errors: v.Data.ErrorMessages}
 		}
 
-		if err == io.EOF {
-			return 0, newStatusError(resp)
-		}
-
-		return 0, err
+		return 0, newStatusError(resp)
 	}
 
 	var v apiTeamResponse

--- a/internal/sirius/add_user_test.go
+++ b/internal/sirius/add_user_test.go
@@ -160,3 +160,17 @@ func TestAddUser(t *testing.T) {
 		})
 	}
 }
+
+func TestAddUserStatusError(t *testing.T) {
+	s := teapotServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	err := client.AddUser(context.Background(), nil, "", "", "", "", nil)
+	assert.Equal(t, StatusError{
+		Code:   http.StatusTeapot,
+		URL:    s.URL + "/auth/user",
+		Method: http.MethodPost,
+	}, err)
+}

--- a/internal/sirius/change_password_test.go
+++ b/internal/sirius/change_password_test.go
@@ -134,3 +134,17 @@ func TestChangePassword(t *testing.T) {
 		})
 	}
 }
+
+func TestChangePasswordStatusError(t *testing.T) {
+	s := teapotServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	err := client.ChangePassword(context.Background(), nil, "", "", "")
+	assert.Equal(t, StatusError{
+		Code:   http.StatusTeapot,
+		URL:    s.URL + "/auth/change-password",
+		Method: http.MethodPost,
+	}, err)
+}

--- a/internal/sirius/client_test.go
+++ b/internal/sirius/client_test.go
@@ -1,0 +1,14 @@
+package sirius
+
+import (
+	"net/http"
+	"net/http/httptest"
+)
+
+func teapotServer() *httptest.Server {
+	return httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTeapot)
+		}),
+	)
+}

--- a/internal/sirius/client_test.go
+++ b/internal/sirius/client_test.go
@@ -1,8 +1,12 @@
 package sirius
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func teapotServer() *httptest.Server {
@@ -11,4 +15,44 @@ func teapotServer() *httptest.Server {
 			w.WriteHeader(http.StatusTeapot)
 		}),
 	)
+}
+
+func invalidJSONServer() *httptest.Server {
+	return httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("1a is not valid json"))
+		}),
+	)
+}
+
+func TestClientError(t *testing.T) {
+	assert.Equal(t, "message", ClientError("message").Error())
+}
+
+func TestValidationError(t *testing.T) {
+	assert.Equal(t, "message", ValidationError{Message: "message"}.Error())
+}
+
+func TestStatusError(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodPost, "/some/url", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusTeapot,
+		Request:    req,
+	}
+
+	err := newStatusError(resp)
+
+	assert.Equal(t, "POST /some/url returned 418", err.Error())
+	assert.Equal(t, "unexpected response from Sirius", err.Title())
+	assert.Equal(t, err, err.Data())
+}
+
+func TestNewRequestBadXsrfToken(t *testing.T) {
+	client, _ := NewClient(http.DefaultClient, "")
+
+	_, err := client.newRequest(context.Background(), http.MethodGet, "/path", nil, []*http.Cookie{
+		{Name: "XSRF-TOKEN", Value: "%"},
+	})
+	assert.Equal(t, ErrUnauthorized, err)
 }

--- a/internal/sirius/edit_my_details.go
+++ b/internal/sirius/edit_my_details.go
@@ -3,7 +3,6 @@ package sirius
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -11,7 +10,6 @@ import (
 
 func (c *Client) EditMyDetails(ctx context.Context, cookies []*http.Cookie, id int, phoneNumber string) error {
 	var v struct {
-		Status           int              `json:"status"`
 		Detail           string           `json:"detail"`
 		ValidationErrors ValidationErrors `json:"validation_errors"`
 	}
@@ -42,19 +40,14 @@ func (c *Client) EditMyDetails(ctx context.Context, cookies []*http.Cookie, id i
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		err = json.NewDecoder(resp.Body).Decode(&v)
-		if err == nil {
+		if err := json.NewDecoder(resp.Body).Decode(&v); err == nil {
 			return &ValidationError{
 				Message: v.Detail,
 				Errors:  v.ValidationErrors,
 			}
 		}
 
-		if err == io.EOF {
-			return newStatusError(resp)
-		}
-
-		return err
+		return newStatusError(resp)
 	}
 
 	return nil

--- a/internal/sirius/edit_my_details_test.go
+++ b/internal/sirius/edit_my_details_test.go
@@ -150,3 +150,17 @@ func TestEditMyDetails(t *testing.T) {
 		})
 	}
 }
+
+func TestEditMyDetailsStatusError(t *testing.T) {
+	s := teapotServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	err := client.EditMyDetails(context.Background(), nil, 47, "")
+	assert.Equal(t, StatusError{
+		Code:   http.StatusTeapot,
+		URL:    s.URL + "/api/v1/users/47/updateTelephoneNumber",
+		Method: http.MethodPut,
+	}, err)
+}

--- a/internal/sirius/edit_team.go
+++ b/internal/sirius/edit_team.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -50,18 +49,13 @@ func (c *Client) EditTeam(ctx context.Context, cookies []*http.Cookie, team Team
 			} `json:"data"`
 		}
 
-		err = json.NewDecoder(resp.Body).Decode(&v)
-		if err == nil {
+		if err := json.NewDecoder(resp.Body).Decode(&v); err == nil {
 			return &ValidationError{
 				Errors: v.Data.Errors,
 			}
 		}
 
-		if err == io.EOF {
-			return newStatusError(resp)
-		}
-
-		return err
+		return newStatusError(resp)
 	}
 
 	return nil

--- a/internal/sirius/edit_team_test.go
+++ b/internal/sirius/edit_team_test.go
@@ -205,3 +205,17 @@ func TestEditTeam(t *testing.T) {
 		})
 	}
 }
+
+func TestEditTeamStatusError(t *testing.T) {
+	s := teapotServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	err := client.EditTeam(context.Background(), nil, Team{ID: 65})
+	assert.Equal(t, StatusError{
+		Code:   http.StatusTeapot,
+		URL:    s.URL + "/api/team/65",
+		Method: http.MethodPut,
+	}, err)
+}

--- a/internal/sirius/edit_user.go
+++ b/internal/sirius/edit_user.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -55,16 +54,11 @@ func (c *Client) EditUser(ctx context.Context, cookies []*http.Cookie, user Auth
 			Message string `json:"message"`
 		}
 
-		err = json.NewDecoder(resp.Body).Decode(&v)
-		if err == nil {
+		if err := json.NewDecoder(resp.Body).Decode(&v); err == nil {
 			return ClientError(v.Message)
 		}
 
-		if err == io.EOF {
-			return newStatusError(resp)
-		}
-
-		return err
+		return newStatusError(resp)
 	}
 
 	return nil

--- a/internal/sirius/has_permission.go
+++ b/internal/sirius/has_permission.go
@@ -27,8 +27,6 @@ type myPermissions struct {
 }
 
 func (c *Client) HasPermission(ctx context.Context, cookies []*http.Cookie, group string, method string) (bool, error) {
-	var v myPermissions
-
 	req, err := c.newRequest(ctx, http.MethodGet, "/api/permission", nil, cookies)
 	if err != nil {
 		return false, err
@@ -48,9 +46,8 @@ func (c *Client) HasPermission(ctx context.Context, cookies []*http.Cookie, grou
 		return false, newStatusError(resp)
 	}
 
-	err = json.NewDecoder(resp.Body).Decode(&v)
-
-	if err != nil {
+	var v myPermissions
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
 		return false, err
 	}
 

--- a/internal/sirius/has_permission.go
+++ b/internal/sirius/has_permission.go
@@ -3,9 +3,7 @@ package sirius
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
-	"strconv"
 	"strings"
 )
 
@@ -47,7 +45,7 @@ func (c *Client) HasPermission(ctx context.Context, cookies []*http.Cookie, grou
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return false, errors.New("returned non-2XX response: " + strconv.Itoa(resp.StatusCode))
+		return false, newStatusError(resp)
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&v)

--- a/internal/sirius/has_permission_test.go
+++ b/internal/sirius/has_permission_test.go
@@ -113,6 +113,20 @@ func TestPermissions(t *testing.T) {
 	}
 }
 
+func TestHasPermissionStatusError(t *testing.T) {
+	s := teapotServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	_, err := client.HasPermission(context.Background(), nil, "", "")
+	assert.Equal(t, StatusError{
+		Code:   http.StatusTeapot,
+		URL:    s.URL + "/api/permission",
+		Method: http.MethodGet,
+	}, err)
+}
+
 func TestPermissionSetChecksPermission(t *testing.T) {
 	permissions := permissionSet{
 		"user": {

--- a/internal/sirius/my_details_test.go
+++ b/internal/sirius/my_details_test.go
@@ -124,3 +124,17 @@ func TestMyDetails(t *testing.T) {
 		})
 	}
 }
+
+func TestMyDetailsStatusError(t *testing.T) {
+	s := teapotServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	_, err := client.MyDetails(context.Background(), nil)
+	assert.Equal(t, StatusError{
+		Code:   http.StatusTeapot,
+		URL:    s.URL + "/api/v1/users/current",
+		Method: http.MethodGet,
+	}, err)
+}

--- a/internal/sirius/search_users.go
+++ b/internal/sirius/search_users.go
@@ -3,10 +3,8 @@ package sirius
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"sort"
-	"strconv"
 	"strings"
 )
 
@@ -69,7 +67,7 @@ func (c *Client) SearchUsers(ctx context.Context, cookies []*http.Cookie, search
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New("returned non-2XX response: " + strconv.Itoa(resp.StatusCode))
+		return nil, newStatusError(resp)
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&apiUserList)

--- a/internal/sirius/search_users.go
+++ b/internal/sirius/search_users.go
@@ -49,8 +49,6 @@ func (c *Client) SearchUsers(ctx context.Context, cookies []*http.Cookie, search
 		return nil, ClientError("Search term must be at least three characters")
 	}
 
-	var apiUserList apiUserList
-
 	req, err := c.newRequest(ctx, http.MethodGet, "/api/search/users?query="+search, nil, cookies)
 	if err != nil {
 		return nil, err
@@ -70,14 +68,12 @@ func (c *Client) SearchUsers(ctx context.Context, cookies []*http.Cookie, search
 		return nil, newStatusError(resp)
 	}
 
-	err = json.NewDecoder(resp.Body).Decode(&apiUserList)
-
-	if err != nil {
+	var v apiUserList
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
 		return nil, err
 	}
 
-	apiUsers := apiUserList.Data
-	var users []User
+	apiUsers := v.Data
 
 	sort.SliceStable(apiUsers, func(i, j int) bool {
 		if strings.EqualFold(apiUsers[i].Surname, apiUsers[j].Surname) {
@@ -87,6 +83,7 @@ func (c *Client) SearchUsers(ctx context.Context, cookies []*http.Cookie, search
 		return strings.ToLower(apiUsers[i].Surname) < strings.ToLower(apiUsers[j].Surname)
 	})
 
+	var users []User
 	for _, u := range apiUsers {
 		user := User{
 			ID:          u.ID,

--- a/internal/sirius/search_users_test.go
+++ b/internal/sirius/search_users_test.go
@@ -123,6 +123,20 @@ func TestSearchUsers(t *testing.T) {
 	}
 }
 
+func TestSearchUsersStatusError(t *testing.T) {
+	s := teapotServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	_, err := client.SearchUsers(context.Background(), nil, "abc")
+	assert.Equal(t, StatusError{
+		Code:   http.StatusTeapot,
+		URL:    s.URL + "/api/search/users?query=abc",
+		Method: http.MethodGet,
+	}, err)
+}
+
 func TestSearchUsersTooShort(t *testing.T) {
 	client, _ := NewClient(http.DefaultClient, "")
 

--- a/internal/sirius/search_users_test.go
+++ b/internal/sirius/search_users_test.go
@@ -144,3 +144,11 @@ func TestSearchUsersTooShort(t *testing.T) {
 	assert.Nil(t, users)
 	assert.Equal(t, ClientError("Search term must be at least three characters"), err)
 }
+
+func TestUserStatus(t *testing.T) {
+	assert.Equal(t, "string", UserStatus("string").String())
+
+	assert.Equal(t, "", UserStatus("string").TagColour())
+	assert.Equal(t, "govuk-tag--grey", UserStatus("Suspended").TagColour())
+	assert.Equal(t, "govuk-tag--orange", UserStatus("Locked").TagColour())
+}

--- a/internal/sirius/team.go
+++ b/internal/sirius/team.go
@@ -32,7 +32,7 @@ func (c *Client) Team(ctx context.Context, cookies []*http.Cookie, id int) (Team
 	}
 
 	var v apiTeamResponse
-	if err = json.NewDecoder(resp.Body).Decode(&v); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
 		return Team{}, err
 	}
 

--- a/internal/sirius/team_test.go
+++ b/internal/sirius/team_test.go
@@ -2,6 +2,7 @@ package sirius
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -170,6 +171,16 @@ func TestTeam(t *testing.T) {
 			}))
 		})
 	}
+}
+
+func TestTeamBadJSONResponse(t *testing.T) {
+	s := invalidJSONServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	_, err := client.Team(context.Background(), nil, 123)
+	assert.IsType(t, &json.UnmarshalTypeError{}, err)
 }
 
 func TestTeamStatusError(t *testing.T) {

--- a/internal/sirius/team_test.go
+++ b/internal/sirius/team_test.go
@@ -27,7 +27,7 @@ func TestTeam(t *testing.T) {
 		setup            func()
 		cookies          []*http.Cookie
 		expectedResponse Team
-		expectedError    func(int) error
+		expectedError    error
 	}{
 		{
 			name: "OK",
@@ -83,7 +83,6 @@ func TestTeam(t *testing.T) {
 				},
 				Type: "ALLOCATIONS",
 			},
-			expectedError: func(port int) error { return nil },
 		},
 		{
 			name: "OKWithLpaTeams",
@@ -132,7 +131,6 @@ func TestTeam(t *testing.T) {
 				},
 				Type: "",
 			},
-			expectedError: func(port int) error { return nil },
 		},
 		{
 			name: "Unauthorized",
@@ -154,41 +152,7 @@ func TestTeam(t *testing.T) {
 					})
 			},
 			expectedResponse: Team{},
-			expectedError:    func(port int) error { return ErrUnauthorized },
-		},
-		{
-			name: "DoesNotExist",
-			id:   3589359,
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("User exists").
-					UponReceiving("A request for a team which doesn't exist").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/api/team/3589359"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusNotFound,
-					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
-			expectedResponse: Team{},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusNotFound,
-					URL:    fmt.Sprintf("http://localhost:%d/api/team/3589359", port),
-					Method: http.MethodGet,
-				}
-			},
+			expectedError:    ErrUnauthorized,
 		},
 	}
 
@@ -201,9 +165,23 @@ func TestTeam(t *testing.T) {
 
 				team, err := client.Team(context.Background(), tc.cookies, tc.id)
 				assert.Equal(t, tc.expectedResponse, team)
-				assert.Equal(t, tc.expectedError(pact.Server.Port), err)
+				assert.Equal(t, tc.expectedError, err)
 				return nil
 			}))
 		})
 	}
+}
+
+func TestTeamStatusError(t *testing.T) {
+	s := teapotServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	_, err := client.Team(context.Background(), nil, 123)
+	assert.Equal(t, StatusError{
+		Code:   http.StatusTeapot,
+		URL:    s.URL + "/api/team/123",
+		Method: http.MethodGet,
+	}, err)
 }

--- a/internal/sirius/team_types.go
+++ b/internal/sirius/team_types.go
@@ -3,9 +3,7 @@ package sirius
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
-	"strconv"
 )
 
 type RefDataTeamType struct {
@@ -18,32 +16,25 @@ func (c *Client) TeamTypes(ctx context.Context, cookies []*http.Cookie) ([]RefDa
 		Data []RefDataTeamType `json:"teamType"`
 	}
 
-	var types []RefDataTeamType
-
 	req, err := c.newRequest(ctx, http.MethodGet, "/api/v1/reference-data?filter=teamType", nil, cookies)
 	if err != nil {
-		return types, err
+		return v.Data, err
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return types, err
+		return v.Data, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return types, ErrUnauthorized
+		return v.Data, ErrUnauthorized
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return types, errors.New("returned non-2XX response: " + strconv.Itoa(resp.StatusCode))
+		return v.Data, newStatusError(resp)
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&v)
-
-	if err != nil {
-		return types, err
-	}
-
-	return v.Data, nil
+	return v.Data, err
 }

--- a/internal/sirius/team_types_test.go
+++ b/internal/sirius/team_types_test.go
@@ -110,3 +110,17 @@ func TestTeamTypes(t *testing.T) {
 		})
 	}
 }
+
+func TestTeamTypesStatusError(t *testing.T) {
+	s := teapotServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	_, err := client.TeamTypes(context.Background(), nil)
+	assert.Equal(t, StatusError{
+		Code:   http.StatusTeapot,
+		URL:    s.URL + "/api/v1/reference-data?filter=teamType",
+		Method: http.MethodGet,
+	}, err)
+}

--- a/internal/sirius/teams_test.go
+++ b/internal/sirius/teams_test.go
@@ -206,3 +206,17 @@ func TestTeamsIgnoredPact(t *testing.T) {
 		})
 	}
 }
+
+func TestTeamsStatusError(t *testing.T) {
+	s := teapotServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	_, err := client.Teams(context.Background(), nil)
+	assert.Equal(t, StatusError{
+		Code:   http.StatusTeapot,
+		URL:    s.URL + "/api/v1/teams",
+		Method: http.MethodGet,
+	}, err)
+}

--- a/internal/sirius/user.go
+++ b/internal/sirius/user.go
@@ -3,10 +3,8 @@ package sirius
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 )
 
 type AuthUser struct {
@@ -49,7 +47,7 @@ func (c *Client) User(ctx context.Context, cookies []*http.Cookie, id int) (Auth
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return AuthUser{}, errors.New("returned non-2XX response: " + strconv.Itoa(resp.StatusCode))
+		return AuthUser{}, newStatusError(resp)
 	}
 
 	var v authUserResponse

--- a/internal/sirius/user.go
+++ b/internal/sirius/user.go
@@ -51,7 +51,9 @@ func (c *Client) User(ctx context.Context, cookies []*http.Cookie, id int) (Auth
 	}
 
 	var v authUserResponse
-	err = json.NewDecoder(resp.Body).Decode(&v)
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		return AuthUser{}, err
+	}
 
 	user := AuthUser{
 		ID:        v.ID,

--- a/internal/sirius/user_test.go
+++ b/internal/sirius/user_test.go
@@ -115,3 +115,17 @@ func TestUser(t *testing.T) {
 		})
 	}
 }
+
+func TestUserStatusError(t *testing.T) {
+	s := teapotServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	_, err := client.User(context.Background(), nil, 123)
+	assert.Equal(t, StatusError{
+		Code:   http.StatusTeapot,
+		URL:    s.URL + "/auth/user/123",
+		Method: http.MethodGet,
+	}, err)
+}

--- a/internal/sirius/user_test.go
+++ b/internal/sirius/user_test.go
@@ -2,6 +2,7 @@ package sirius
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -114,6 +115,16 @@ func TestUser(t *testing.T) {
 			}))
 		})
 	}
+}
+
+func TestUserBadJSONResponse(t *testing.T) {
+	s := invalidJSONServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	_, err := client.User(context.Background(), nil, 123)
+	assert.IsType(t, &json.UnmarshalTypeError{}, err)
 }
 
 func TestUserStatusError(t *testing.T) {


### PR DESCRIPTION
- Moved the `StatusError` assertions to separate tests (and added missing ones)
- Removed the possibility of returned the error from decoding the JSON when a unexpected status code is returned (as it wouldn't provide much useful information vs. status code + method + path)