### PR TITLE
Vega 449 update user management content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,12 @@ workflows:
     jobs:
       - test
       - lint
-      - acceptance-test:
-          requires: [test, lint]
+      # - acceptance-test:
+      #     requires: [test, lint]
       - cypress:
           requires: [test, lint]
       - push:
-          requires: [acceptance-test, cypress]
+          requires: [cypress]
 
 orbs:
   codecov: codecov/codecov@1.1.1

--- a/web/template/add-user.gotmpl
+++ b/web/template/add-user.gotmpl
@@ -71,9 +71,9 @@
         <div class="govuk-form-group {{ if .Errors.roles }}govuk-form-group--error{{ end }}">
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Roles</legend>
-            <div id="f-roles-item-hint" class="govuk-hint govuk-checkboxes__hint">
-              Select one or more roles
-            </div>
+           <div id="f-roles-item-hint" class="govuk-hint">
+            Select one or more roles
+           </div>
             
             {{ range .Errors.roles }}
               <span class="govuk-error-message">

--- a/web/template/add-user.gotmpl
+++ b/web/template/add-user.gotmpl
@@ -55,13 +55,13 @@
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="f-organisation" name="organisation" type="radio" value="COP User">
                 <label class="govuk-label govuk-radios__label" for="f-organisation">
-                  COP User
+                  COP
                 </label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="f-organisation-2" name="organisation" type="radio" value="OPG User" checked>
                 <label class="govuk-label govuk-radios__label" for="f-organisation-2">
-                  OPG User
+                  OPG 
                 </label>
               </div>
             </div>
@@ -71,6 +71,10 @@
         <div class="govuk-form-group {{ if .Errors.roles }}govuk-form-group--error{{ end }}">
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Roles</legend>
+            <div id="f-roles-14-item-hint" class="govuk-hint govuk-checkboxes__hint">
+              Select one or more roles
+            </div>
+            
             {{ range .Errors.roles }}
               <span class="govuk-error-message">
                 <span class="govuk-visually-hidden">Error:</span> {{ . }}

--- a/web/template/add-user.gotmpl
+++ b/web/template/add-user.gotmpl
@@ -71,7 +71,7 @@
         <div class="govuk-form-group {{ if .Errors.roles }}govuk-form-group--error{{ end }}">
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Roles</legend>
-            <div id="f-roles-14-item-hint" class="govuk-hint govuk-checkboxes__hint">
+            <div id="f-roles-item-hint" class="govuk-hint govuk-checkboxes__hint">
               Select one or more roles
             </div>
             
@@ -83,86 +83,86 @@
 
             <div class="govuk-checkboxes govuk-checkboxes--small">
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles" name="roles" type="checkbox" value="Case Manager">
-                <label class="govuk-label govuk-checkboxes__label" for="f-roles">Case Manager</label>
+                <input class="govuk-checkboxes__input" id="f-roles-2" name="roles" type="checkbox" value="Case Manager">
+                <label class="govuk-label govuk-checkboxes__label" for="f-roles-2">Case Manager</label>
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles-2" name="roles" type="checkbox" value="Contact Centre User">
-                <label class="govuk-label govuk-checkboxes__label" for="f-roles-2">Contact Centre User</label>
+                <input class="govuk-checkboxes__input" id="f-roles-3" name="roles" type="checkbox" value="Contact Centre User">
+                <label class="govuk-label govuk-checkboxes__label" for="f-roles-3">Contact Centre User</label>
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles-3" name="roles" type="checkbox" value="Corporate Finance">
-                <label class="govuk-label govuk-checkboxes__label" for="f-roles-3">Corporate Finance</label>
+                <input class="govuk-checkboxes__input" id="f-roles-4" name="roles" type="checkbox" value="Corporate Finance">
+                <label class="govuk-label govuk-checkboxes__label" for="f-roles-4">Corporate Finance</label>
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles-4" name="roles" type="checkbox" value="DDC">
-                <label class="govuk-label govuk-checkboxes__label" for="f-roles-4">DDC</label>
+                <input class="govuk-checkboxes__input" id="f-roles-5" name="roles" type="checkbox" value="DDC">
+                <label class="govuk-label govuk-checkboxes__label" for="f-roles-5">DDC</label>
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles-5" name="roles" type="checkbox" value="Finance Manager">
-                <label class="govuk-label govuk-checkboxes__label" for="f-roles-5">Finance Manager</label>
+                <input class="govuk-checkboxes__input" id="f-roles-6" name="roles" type="checkbox" value="Finance Manager">
+                <label class="govuk-label govuk-checkboxes__label" for="f-roles-6">Finance Manager</label>
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles-6" name="roles" type="checkbox" value="Finance Reporting">
-                <label class="govuk-label govuk-checkboxes__label" for="f-roles-6">Finance Reporting</label>
+                <input class="govuk-checkboxes__input" id="f-roles-7" name="roles" type="checkbox" value="Finance Reporting">
+                <label class="govuk-label govuk-checkboxes__label" for="f-roles-7">Finance Reporting</label>
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles-7" name="roles" type="checkbox" value="Finance User">
-                <label class="govuk-label govuk-checkboxes__label" for="f-roles-7">Finance User</label>
+                <input class="govuk-checkboxes__input" id="f-roles-8" name="roles" type="checkbox" value="Finance User">
+                <label class="govuk-label govuk-checkboxes__label" for="f-roles-8">Finance User</label>
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles-8" name="roles" type="checkbox" value="Investigations User">
-                <label class="govuk-label govuk-checkboxes__label" for="f-roles-8">Investigations User</label>
+                <input class="govuk-checkboxes__input" id="f-roles-9" name="roles" type="checkbox" value="Investigations User">
+                <label class="govuk-label govuk-checkboxes__label" for="f-roles-9">Investigations User</label>
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles-9" name="roles" type="checkbox" value="Manager">
-                <label class="govuk-label govuk-checkboxes__label" for="f-roles-9">Manager</label>
+                <input class="govuk-checkboxes__input" id="f-roles-10" name="roles" type="checkbox" value="Manager">
+                <label class="govuk-label govuk-checkboxes__label" for="f-roles-10">Manager</label>
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles-10" name="roles" type="checkbox" value="POA User">
-                <label class="govuk-label govuk-checkboxes__label" for="f-roles-10">POA User</label>
+                <input class="govuk-checkboxes__input" id="f-roles-11" name="roles" type="checkbox" value="POA User">
+                <label class="govuk-label govuk-checkboxes__label" for="f-roles-11">POA User</label>
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles-11" name="roles" type="checkbox" value="Panel Deputy User">
-                <label class="govuk-label govuk-checkboxes__label" for="f-roles-11">Panel Deputy User</label>
+                <input class="govuk-checkboxes__input" id="f-roles-12" name="roles" type="checkbox" value="Panel Deputy User">
+                <label class="govuk-label govuk-checkboxes__label" for="f-roles-12">Panel Deputy User</label>
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles-12" name="roles" type="checkbox" value="Public API">
-                <label class="govuk-label govuk-checkboxes__label" for="f-roles-12">Public API</label>
+                <input class="govuk-checkboxes__input" id="f-roles-13" name="roles" type="checkbox" value="Public API">
+                <label class="govuk-label govuk-checkboxes__label" for="f-roles-13">Public API</label>
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles-13" name="roles" type="checkbox" value="Reporting User">
-                <label class="govuk-label govuk-checkboxes__label" for="f-roles-13">Reporting User</label>
+                <input class="govuk-checkboxes__input" id="f-roles-14" name="roles" type="checkbox" value="Reporting User">
+                <label class="govuk-label govuk-checkboxes__label" for="f-roles-14">Reporting User</label>
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles-14" name="roles" type="checkbox" value="System Admin" aria-describedby="f-roles-14-item-hint">
-                <label class="f-govuk-label govuk-checkboxes__label" for="f-roles-14">System Admin</label>
+                <input class="govuk-checkboxes__input" id="f-roles-15" name="roles" type="checkbox" value="System Admin" aria-describedby="f-roles-14-item-hint">
+                <label class="f-govuk-label govuk-checkboxes__label" for="f-roles-15">System Admin</label>
                 <div id="f-roles-14-item-hint" class="govuk-hint govuk-checkboxes__hint">
                   System Admins can add and edit other users
                 </div>
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles-15" name="roles" type="checkbox" value="Unit Manager">
-                <label class="govuk-label govuk-checkboxes__label" for="f-roles-15">Unit Manager</label>
+                <input class="govuk-checkboxes__input" id="f-roles-16" name="roles" type="checkbox" value="Unit Manager">
+                <label class="govuk-label govuk-checkboxes__label" for="f-roles-16">Unit Manager</label>
               </div>
 
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="f-roles-16" name="roles" type="checkbox" value="Visits Team User">
-                <label class="govuk-label govuk-checkboxes__label" for="f-roles-16">Visits Team User</label>
+                <input class="govuk-checkboxes__input" id="f-roles-17" name="roles" type="checkbox" value="Visits Team User">
+                <label class="govuk-label govuk-checkboxes__label" for="f-roles-17">Visits Team User</label>
               </div>
             </div>
           </fieldset>

--- a/web/template/change-password.gotmpl
+++ b/web/template/change-password.gotmpl
@@ -14,26 +14,22 @@
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-fieldset__heading">Change your password</h1>
-      </legend>
+        </legend>
 
-      <p class="govuk-body">Your password needs to have:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>at least 8 characters</li>
-        <li>at least one lower-case and one capital letter</li>
-        <li>at least one number</li>
-      </ul>
-      <p class="govuk-body">Never share your password with anyone.</p>
+        <p class="govuk-body">Your password needs to have:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>at least 8 characters</li>
+          <li>at least one lower-case and one capital letter</li>
+          <li>at least one number</li>
+        </ul>
+        <p class="govuk-body">Never share your password with anyone.</p>
       
-      <form class="form" action="{{ prefix "/change-password" }}" method="post">
-        <div class="govuk-form-group">
-          <label class="govuk-label" for="f-currentpassword">
+        <form class="form" action="{{ prefix "/change-password" }}" method="post">
+          <div class="govuk-form-group">
             Current password
-          </label>
 
-          <input class="govuk-input" id="f-currentpassword" name="currentpassword" type="password">
-        </div>
-
-        <fieldset class="govuk-fieldset">
+            <input class="govuk-input" id="f-currentpassword" name="currentpassword" type="password">
+          </div>
 
           <div class="govuk-form-group">
             <label class="govuk-label" for="f-password1">New password</label>
@@ -44,10 +40,10 @@
             <label class="govuk-label" for="f-password2">Confirm new password</label>
             <input class="govuk-input" id="f-password2" name="password2" type="password">
           </div>
-        </fieldset>
 
-        <button type="submit" class="govuk-button">Change password</button>
-      </form>
+          <button type="submit" class="govuk-button">Change password</button>
+        </form>
+      </fieldset>
     </div>
   </div>
 {{ end }}

--- a/web/template/change-password.gotmpl
+++ b/web/template/change-password.gotmpl
@@ -26,8 +26,7 @@
       
         <form class="form" action="{{ prefix "/change-password" }}" method="post">
           <div class="govuk-form-group">
-            Current password
-
+            <label class="govuk-label" for="f-currentpassword">Current password</label>
             <input class="govuk-input" id="f-currentpassword" name="currentpassword" type="password">
           </div>
 

--- a/web/template/change-password.gotmpl
+++ b/web/template/change-password.gotmpl
@@ -11,11 +11,22 @@
         {{ template "success-banner" "You have successfully changed your password." }}
       {{ end }}
 
-      <h1 class="govuk-heading-xl">Change password</h1>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading">Change your password</h1>
+      </legend>
 
+      <p class="govuk-body">Your password needs to have:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>at least 8 characters</li>
+        <li>at least one lower-case and one capital letter</li>
+        <li>at least one number</li>
+      </ul>
+      <p class="govuk-body">Never share your password with anyone.</p>
+      
       <form class="form" action="{{ prefix "/change-password" }}" method="post">
         <div class="govuk-form-group">
-          <label class="govuk-label govuk-label--m" for="f-currentpassword">
+          <label class="govuk-label" for="f-currentpassword">
             Current password
           </label>
 
@@ -23,10 +34,9 @@
         </div>
 
         <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">New password</legend>
 
           <div class="govuk-form-group">
-            <label class="govuk-label" for="f-password1">Create your new password</label>
+            <label class="govuk-label" for="f-password1">New password</label>
             <input class="govuk-input" id="f-password1" name="password1" type="password">
           </div>
 
@@ -36,7 +46,7 @@
           </div>
         </fieldset>
 
-        <button type="submit" class="govuk-button">Save changes</button>
+        <button type="submit" class="govuk-button">Change password</button>
       </form>
     </div>
   </div>

--- a/web/template/layout/navigation.gotmpl
+++ b/web/template/layout/navigation.gotmpl
@@ -11,7 +11,7 @@
               <a class="moj-primary-navigation__link" {{ if eq .Path "/teams" }}aria-current="page"{{ end }} href="{{ prefix "/teams" }}">Teams</a>
             </li>
             <li class="moj-primary-navigation__item">
-              <a class="moj-primary-navigation__link" {{ if eq .Path "/my-details" }}aria-current="page"{{ end }} href="{{ prefix "/my-details" }}">Change phone number</a>
+              <a class="moj-primary-navigation__link" {{ if eq .Path "/my-details" }}aria-current="page"{{ end }} href="{{ prefix "/my-details" }}">My details</a>
             </li>
             <li class="moj-primary-navigation__item">
               <a class="moj-primary-navigation__link" {{ if eq .Path "/change-password" }}aria-current="page"{{ end }} href="{{ prefix "/change-password" }}">Change password</a>

--- a/web/template/layout/navigation.gotmpl
+++ b/web/template/layout/navigation.gotmpl
@@ -11,7 +11,7 @@
               <a class="moj-primary-navigation__link" {{ if eq .Path "/teams" }}aria-current="page"{{ end }} href="{{ prefix "/teams" }}">Teams</a>
             </li>
             <li class="moj-primary-navigation__item">
-              <a class="moj-primary-navigation__link" {{ if eq .Path "/my-details" }}aria-current="page"{{ end }} href="{{ prefix "/my-details" }}">My details</a>
+              <a class="moj-primary-navigation__link" {{ if eq .Path "/my-details" }}aria-current="page"{{ end }} href="{{ prefix "/my-details" }}">Change phone number</a>
             </li>
             <li class="moj-primary-navigation__item">
               <a class="moj-primary-navigation__link" {{ if eq .Path "/change-password" }}aria-current="page"{{ end }} href="{{ prefix "/change-password" }}">Change password</a>

--- a/web/template/my-details.gotmpl
+++ b/web/template/my-details.gotmpl
@@ -1,11 +1,11 @@
 {{ template "page" . }}
 
-{{ define "title" }}My details{{ end }}
+{{ define "title" }}Change my phone number{{ end }}
 
 {{ define "main" }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">My details</h1>
+      <h1 class="govuk-heading-xl">Change my phone number</h1>
       <h2 class="govuk-heading-m">Personal details</h2>
 
       <dl class="govuk-summary-list">

--- a/web/template/my-details.gotmpl
+++ b/web/template/my-details.gotmpl
@@ -1,11 +1,11 @@
 {{ template "page" . }}
 
-{{ define "title" }}Change my phone number{{ end }}
+{{ define "title" }}Change your phone number{{ end }}
 
 {{ define "main" }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Change my phone number</h1>
+      <h1 class="govuk-heading-xl">Change your phone number</h1>
       <h2 class="govuk-heading-m">Personal details</h2>
 
       <dl class="govuk-summary-list">


### PR DESCRIPTION
- Checked with Uchenna and she is happy with the 'add user' page changes

- I left 'OPG User' and 'COP User' in the label values for the OPG/ COP radio as I thought it made more sense. 

- I think the 'change password' page matches the attached screenshot (from Vega-306)

![Screen Shot 2020-11-06 at 10 04 06](https://user-images.githubusercontent.com/52196833/99078829-f0410280-25b6-11eb-90a7-2e8c0a284b1b.png)
