### PR TITLE
VEGA-463 Use older alpine to use older chromium

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,10 @@ workflows:
     jobs:
       - test
       - lint
-      # - acceptance-test:
-      #     requires: [test, lint]
-      - cypress:
+      - acceptance-test:
           requires: [test, lint]
+      - cypress:
+          requires: [acceptance-test]
       - push:
           requires: [cypress]
 

--- a/docker/puppeteer/Dockerfile
+++ b/docker/puppeteer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.13.1-alpine3.12
+FROM node:14.13.1-alpine3.11
 
 RUN apk add --no-cache \
       chromium \


### PR DESCRIPTION
The chromium package in alpine3.12 got bumped from 83 to 86, which seems to cause new behaviour around forcing SSL. Downgrading to alpine3.11 gives us chromium 81 which doesn't have this problem.