### PR TITLE
VEGA-513: Remove default for SIRIUS_PUBLIC_URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func main() {
 	port := getEnv("PORT", "8080")
 	webDir := getEnv("WEB_DIR", "web")
 	siriusURL := getEnv("SIRIUS_URL", "http://localhost:9001")
-	siriusPublicURL := getEnv("SIRIUS_PUBLIC_URL", "http://localhost:9001")
+	siriusPublicURL := getEnv("SIRIUS_PUBLIC_URL", "")
 	prefix := getEnv("PREFIX", "")
 
 	layouts, _ := template.


### PR DESCRIPTION
An empty environment variable is a valid base URL also.