### PR TITLE
VEGA-516: Remove trailing slash from /teams/add

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -59,7 +59,7 @@ func New(logger Logger, client Client, templates map[string]*template.Template, 
 			allowRoles(client, "System Admin", "Manager")(
 				viewTeam(client, templates["team.gotmpl"]))))
 
-	mux.Handle("/teams/add/",
+	mux.Handle("/teams/add",
 		wrap(
 			systemAdminOnly(
 				addTeam(client, templates["team-add.gotmpl"]))))


### PR DESCRIPTION
We only use trailing slashes in URLs which are followed by parameters (like `/teams/edit/(id)`)