### PR TITLE
VEGA-532: Allow system admins to unlock accounts

### DIFF
--- a/cypress/integration/unlock_user.spec.js
+++ b/cypress/integration/unlock_user.spec.js
@@ -1,0 +1,12 @@
+describe("Unlock user", () => {
+    beforeEach(() => {
+        cy.setCookie("Other", "other");
+        cy.setCookie("XSRF-TOKEN", "abcde");
+        cy.visit("/unlock-user/123");
+    });
+
+    it("allows me to unlock a user", () => {
+        cy.contains("button", "Unlock account").click();
+        cy.url().should("include", "/edit-user/123");
+    });
+});

--- a/docker/puppeteer/pa11yci.json
+++ b/docker/puppeteer/pa11yci.json
@@ -25,7 +25,9 @@
         "http://app:8888/my-details/edit",
         "http://app:8888/change-password",
         "http://app:8888/add-user",
+        "http://app:8888/delete-user/123",
         "http://app:8888/edit-user/123",
+        "http://app:8888/unlock-user/123",
         "http://app:8888/teams",
         "http://app:8888/teams/edit/123",
         "http://app:8888/teams/123"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,6 +27,7 @@ type Client interface {
 	ListUsersClient
 	MyDetailsClient
 	ResendConfirmationClient
+	UnlockUserClient
 	ViewTeamClient
 }
 
@@ -100,6 +101,11 @@ func New(logger Logger, client Client, templates map[string]*template.Template, 
 		wrap(
 			systemAdminOnly(
 				editUser(client, templates["edit-user.gotmpl"], deleteUserEnabled))))
+
+	mux.Handle("/unlock-user/",
+		wrap(
+			systemAdminOnly(
+				unlockUser(client, templates["unlock-user.gotmpl"]))))
 
 	mux.Handle("/delete-user/",
 		wrap(

--- a/internal/server/unlock_user.go
+++ b/internal/server/unlock_user.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/ministryofjustice/opg-sirius-user-management/internal/sirius"
+)
+
+type UnlockUserClient interface {
+	User(sirius.Context, int) (sirius.AuthUser, error)
+	EditUser(sirius.Context, sirius.AuthUser) error
+}
+
+type unlockUserVars struct {
+	Path      string
+	XSRFToken string
+	User      sirius.AuthUser
+	Errors    sirius.ValidationErrors
+}
+
+func unlockUser(client UnlockUserClient, tmpl Template) Handler {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/unlock-user/"))
+		if err != nil {
+			return StatusError(http.StatusNotFound)
+		}
+
+		if r.Method != http.MethodGet && r.Method != http.MethodPost {
+			return StatusError(http.StatusMethodNotAllowed)
+		}
+
+		ctx := getContext(r)
+
+		user, err := client.User(ctx, id)
+		if err != nil {
+			return err
+		}
+
+		vars := unlockUserVars{
+			Path:      r.URL.Path,
+			XSRFToken: ctx.XSRFToken,
+			User:      user,
+		}
+
+		if r.Method == http.MethodPost {
+			user.Locked = false
+			err := client.EditUser(ctx, user)
+
+			if _, ok := err.(sirius.ClientError); ok {
+				vars.Errors = sirius.ValidationErrors{
+					"": {
+						"": err.Error(),
+					},
+				}
+
+				w.WriteHeader(http.StatusBadRequest)
+			} else if err != nil {
+				return err
+			} else {
+				return RedirectError(fmt.Sprintf("/edit-user/%d", user.ID))
+			}
+		}
+
+		return tmpl.ExecuteTemplate(w, "page", vars)
+	}
+}

--- a/internal/server/unlock_user_test.go
+++ b/internal/server/unlock_user_test.go
@@ -1,0 +1,197 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-user-management/internal/sirius"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockUnlockUserClient struct {
+	user struct {
+		count   int
+		lastCtx sirius.Context
+		lastID  int
+		data    sirius.AuthUser
+		err     error
+	}
+
+	editUser struct {
+		count    int
+		lastCtx  sirius.Context
+		lastUser sirius.AuthUser
+		err      error
+	}
+}
+
+func (m *mockUnlockUserClient) User(ctx sirius.Context, id int) (sirius.AuthUser, error) {
+	m.user.count += 1
+	m.user.lastCtx = ctx
+	m.user.lastID = id
+
+	return m.user.data, m.user.err
+}
+
+func (m *mockUnlockUserClient) EditUser(ctx sirius.Context, user sirius.AuthUser) error {
+	m.editUser.count += 1
+	m.editUser.lastCtx = ctx
+	m.editUser.lastUser = user
+
+	return m.editUser.err
+}
+
+func TestGetUnlockUser(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockUnlockUserClient{}
+	client.user.data = sirius.AuthUser{Firstname: "test"}
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/unlock-user/123", nil)
+
+	err := unlockUser(client, template)(w, r)
+	assert.Nil(err)
+
+	assert.Equal(1, client.user.count)
+	assert.Equal(123, client.user.lastID)
+	assert.Equal(0, client.editUser.count)
+
+	assert.Equal(1, template.count)
+	assert.Equal("page", template.lastName)
+	assert.Equal(unlockUserVars{
+		Path: "/unlock-user/123",
+		User: client.user.data,
+	}, template.lastVars)
+}
+
+func TestGetUnlockUserError(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedError := errors.New("oops")
+
+	client := &mockUnlockUserClient{}
+	client.user.err = expectedError
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/unlock-user/123", nil)
+
+	err := unlockUser(client, template)(w, r)
+	assert.Equal(expectedError, err)
+
+	assert.Equal(1, client.user.count)
+	assert.Equal(123, client.user.lastID)
+	assert.Equal(0, client.editUser.count)
+}
+
+func TestGetUnlockUserBadPath(t *testing.T) {
+	for name, path := range map[string]string{
+		"empty":       "/unlock-user/",
+		"non-numeric": "/unlock-user/hello",
+		"suffixed":    "/unlock-user/123/no",
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			client := &mockUnlockUserClient{}
+			template := &mockTemplate{}
+
+			w := httptest.NewRecorder()
+			r, _ := http.NewRequest("GET", path, nil)
+
+			err := unlockUser(client, template)(w, r)
+			assert.Equal(StatusError(http.StatusNotFound), err)
+
+			assert.Equal(0, client.user.count)
+			assert.Equal(0, client.editUser.count)
+			assert.Equal(0, template.count)
+		})
+	}
+}
+
+func TestPostUnlockUser(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockUnlockUserClient{}
+	client.user.data = sirius.AuthUser{ID: 123, Email: "user@opgtest.com", Locked: true}
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("POST", "/unlock-user/123", nil)
+
+	err := unlockUser(client, template)(w, r)
+	assert.Equal(RedirectError("/edit-user/123"), err)
+
+	assert.Equal(1, client.editUser.count)
+	assert.Equal(getContext(r), client.editUser.lastCtx)
+	assert.Equal(sirius.AuthUser{
+		ID:     123,
+		Email:  "user@opgtest.com",
+		Locked: false,
+	}, client.editUser.lastUser)
+
+	assert.Equal(1, client.user.count)
+	assert.Equal(0, template.count)
+}
+
+func TestPostUnlockUserClientError(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockUnlockUserClient{}
+	client.editUser.err = sirius.ClientError("problem")
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("POST", "/unlock-user/123", nil)
+
+	err := unlockUser(client, template)(w, r)
+	assert.Nil(err)
+
+	assert.Equal(1, client.user.count)
+	assert.Equal(1, client.editUser.count)
+
+	assert.Equal(1, template.count)
+	assert.Equal("page", template.lastName)
+	assert.Equal(unlockUserVars{
+		Path: "/unlock-user/123",
+		User: client.user.data,
+		Errors: sirius.ValidationErrors{
+			"": {
+				"": "problem",
+			},
+		},
+	}, template.lastVars)
+}
+
+func TestPostUnlockUserOtherError(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedErr := errors.New("oops")
+	client := &mockUnlockUserClient{}
+	client.editUser.err = expectedErr
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("POST", "/unlock-user/123", nil)
+
+	err := unlockUser(client, template)(w, r)
+	assert.Equal(expectedErr, err)
+
+	assert.Equal(1, client.user.count)
+	assert.Equal(1, client.editUser.count)
+	assert.Equal(0, template.count)
+}
+
+func TestPutUnlockUser(t *testing.T) {
+	assert := assert.New(t)
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("PUT", "/unlock-user/123", nil)
+
+	err := unlockUser(nil, nil)(w, r)
+	assert.Equal(StatusError(http.StatusMethodNotAllowed), err)
+}

--- a/web/template/edit-user.gotmpl
+++ b/web/template/edit-user.gotmpl
@@ -27,6 +27,15 @@
           <div class="moj-banner__message">User has not activated their account yet.</div>
         </div>
       {{ end }}
+      {{ if .User.Locked }}
+        <div class="moj-banner">
+          <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25"><path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
+          C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z"></path></svg>
+          <div class="moj-banner__message">
+            User account is locked, do you want to <a class="govuk-link" href="{{ prefix (printf "/unlock-user/%d" .User.ID) }}">unlock it</a>?
+          </div>
+        </div>
+      {{ end }}
     </div>
 
     <div class="govuk-grid-column-full">

--- a/web/template/unlock-user.gotmpl
+++ b/web/template/unlock-user.gotmpl
@@ -1,0 +1,28 @@
+{{ template "page" . }}
+
+{{ define "backlink" }}
+  <a class="govuk-back-link" href="{{ prefix (printf "/edit-user/%d" .User.ID) }}">Back</a>
+{{ end }}
+
+{{ define "title" }}
+  Unlock account
+{{ end }}
+
+{{ define "main" }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ template "error-summary" .Errors }}
+      <h1 class="govuk-heading-xl">Unlock account</h1>
+
+      <p class="govuk-body">
+          Are you sure you want to unlock <strong>{{ .User.Firstname }} {{ .User.Surname }}'s</strong> account?
+      </p>
+
+      <form class="form" action="" method="post">
+        <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}" />
+        <button type="submit" class="govuk-button govuk-!-margin-right-1">Unlock account</button>
+        <a href="{{ prefix (printf "/edit-user/%d" .User.ID) }}" class="govuk-button govuk-button--secondary">Cancel</a>
+      </form>
+    </div>
+  </div>
+{{ end }}


### PR DESCRIPTION
Adds a popup on the edit page of locked user accounts, inviting admins to unlock the account. After a confirmation page, the account status is set back to "active".