### PR TITLE
VEGA-510: Use full SHA1 for consumer version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           path: /tmp/test-results
       - run:
           name: Publish pacts
-          command: PACT_TAG=$CIRCLE_BRANCH PACT_CONSUMER_VERSION=$(echo $CIRCLE_SHA1) go run internal/pact/publish.go
+          command: PACT_TAG=$CIRCLE_BRANCH PACT_CONSUMER_VERSION=$CIRCLE_SHA1 go run internal/pact/publish.go
           environment:
             PACT_DIR: ./pacts
             PACT_BROKER_URL: https://pact-broker.api.opg.service.justice.gov.uk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           path: /tmp/test-results
       - run:
           name: Publish pacts
-          command: PACT_TAG=$CIRCLE_BRANCH PACT_CONSUMER_VERSION=$(echo $CIRCLE_SHA1 | cut -c -7) go run internal/pact/publish.go
+          command: PACT_TAG=$CIRCLE_BRANCH PACT_CONSUMER_VERSION=$(echo $CIRCLE_SHA1) go run internal/pact/publish.go
           environment:
             PACT_DIR: ./pacts
             PACT_BROKER_URL: https://pact-broker.api.opg.service.justice.gov.uk


### PR DESCRIPTION
This means the GitHub API knows where to add the status check after verifying the Pact