### PR TITLE
VEGA-401: Give sysadmin users the ability to delete team entities

### DIFF
--- a/cypress/integration/delete_team.spec.js
+++ b/cypress/integration/delete_team.spec.js
@@ -1,0 +1,16 @@
+describe("Delete a team", () => {
+    beforeEach(() => {
+        cy.setCookie("Other", "other");
+        cy.setCookie("XSRF-TOKEN", "abcde");
+        cy.visit("/teams/delete/65");
+    });
+
+    it("shows the team details", () => {
+        cy.get(".govuk-body").should("contain", "Are you sure you want to delete the team Cool Team?");
+    });
+
+    it("allows me to delete the team", () => {
+        cy.contains("button", "Delete team").click();
+        cy.url().should("include", "/teams");
+    });
+});

--- a/docker/puppeteer/pa11yci.json
+++ b/docker/puppeteer/pa11yci.json
@@ -29,7 +29,8 @@
         "http://app:8888/edit-user/123",
         "http://app:8888/unlock-user/123",
         "http://app:8888/teams",
-        "http://app:8888/teams/edit/123",
-        "http://app:8888/teams/123"
+        "http://app:8888/teams/delete/65",
+        "http://app:8888/teams/edit/65",
+        "http://app:8888/teams/65"
     ]
 }

--- a/docker/puppeteer/pa11yci.json
+++ b/docker/puppeteer/pa11yci.json
@@ -12,7 +12,7 @@
             "WCAG2AA.Principle1.Guideline1_3.1_3_1.F92,ARIA4",
             "definition-list"
         ],
-        "hideElements": ".govuk-back-link",
+        "hideElements": ".govuk-back-link, input[type='radio'][aria-expanded]",
         "runners": [
             "axe",
             "htmlcs"

--- a/internal/server/delete_team.go
+++ b/internal/server/delete_team.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/ministryofjustice/opg-sirius-user-management/internal/sirius"
+)
+
+type DeleteTeamClient interface {
+	Team(sirius.Context, int) (sirius.Team, error)
+	DeleteTeam(sirius.Context, int) error
+}
+
+type deleteTeamVars struct {
+	Path           string
+	XSRFToken      string
+	Team           sirius.Team
+	Errors         sirius.ValidationErrors
+	SuccessMessage string
+}
+
+func deleteTeam(client DeleteTeamClient, tmpl Template) Handler {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		id, err := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/teams/delete/"))
+		if err != nil {
+			return StatusError(http.StatusNotFound)
+		}
+
+		if r.Method != http.MethodGet && r.Method != http.MethodPost {
+			return StatusError(http.StatusMethodNotAllowed)
+		}
+
+		ctx := getContext(r)
+
+		team, err := client.Team(ctx, id)
+		if err != nil {
+			return err
+		}
+
+		vars := deleteTeamVars{
+			Path:      r.URL.Path,
+			XSRFToken: ctx.XSRFToken,
+			Team:      team,
+		}
+
+		if r.Method == http.MethodPost {
+			err := client.DeleteTeam(ctx, id)
+
+			if _, ok := err.(sirius.ClientError); ok {
+				vars.Errors = sirius.ValidationErrors{
+					"": {
+						"": err.Error(),
+					},
+				}
+
+				w.WriteHeader(http.StatusBadRequest)
+			} else if err != nil {
+				return err
+			} else {
+				vars.SuccessMessage = fmt.Sprintf("The team \"%s\" was deleted.", team.DisplayName)
+			}
+		}
+
+		return tmpl.ExecuteTemplate(w, "page", vars)
+	}
+}

--- a/internal/server/delete_team_test.go
+++ b/internal/server/delete_team_test.go
@@ -1,0 +1,198 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-user-management/internal/sirius"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockDeleteTeamClient struct {
+	team struct {
+		count   int
+		lastCtx sirius.Context
+		lastID  int
+		data    sirius.Team
+		err     error
+	}
+
+	deleteTeam struct {
+		count      int
+		lastCtx    sirius.Context
+		lastTeamID int
+		err        error
+	}
+}
+
+func (m *mockDeleteTeamClient) Team(ctx sirius.Context, id int) (sirius.Team, error) {
+	m.team.count += 1
+	m.team.lastCtx = ctx
+	m.team.lastID = id
+
+	return m.team.data, m.team.err
+}
+
+func (m *mockDeleteTeamClient) DeleteTeam(ctx sirius.Context, teamID int) error {
+	m.deleteTeam.count += 1
+	m.deleteTeam.lastCtx = ctx
+	m.deleteTeam.lastTeamID = teamID
+
+	return m.deleteTeam.err
+}
+
+func TestGetDeleteTeam(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockDeleteTeamClient{}
+	client.team.data = sirius.Team{DisplayName: "Filing - Pool 5"}
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/teams/delete/461", nil)
+
+	err := deleteTeam(client, template)(w, r)
+	assert.Nil(err)
+
+	assert.Equal(1, client.team.count)
+	assert.Equal(461, client.team.lastID)
+	assert.Equal(0, client.deleteTeam.count)
+
+	assert.Equal(1, template.count)
+	assert.Equal("page", template.lastName)
+	assert.Equal(deleteTeamVars{
+		Path: "/teams/delete/461",
+		Team: client.team.data,
+	}, template.lastVars)
+}
+
+func TestGetDeleteTeamError(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedError := errors.New("oops")
+
+	client := &mockDeleteTeamClient{}
+	client.team.err = expectedError
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/teams/delete/461", nil)
+
+	err := deleteTeam(client, template)(w, r)
+	assert.Equal(expectedError, err)
+
+	assert.Equal(1, client.team.count)
+	assert.Equal(461, client.team.lastID)
+	assert.Equal(0, client.deleteTeam.count)
+}
+
+func TestGetDeleteTeamBadPath(t *testing.T) {
+	for name, path := range map[string]string{
+		"empty":       "/teams/delete/",
+		"non-numeric": "/teams/delete/hello",
+		"suffixed":    "/teams/delete/461/no",
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			client := &mockDeleteTeamClient{}
+			template := &mockTemplate{}
+
+			w := httptest.NewRecorder()
+			r, _ := http.NewRequest("GET", path, nil)
+
+			err := deleteTeam(client, template)(w, r)
+			assert.Equal(StatusError(http.StatusNotFound), err)
+
+			assert.Equal(0, client.team.count)
+			assert.Equal(0, client.deleteTeam.count)
+			assert.Equal(0, template.count)
+		})
+	}
+}
+
+func TestPostDeleteTeam(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockDeleteTeamClient{}
+	client.team.data = sirius.Team{DisplayName: "Filing - Pool 5"}
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("POST", "/teams/delete/461", nil)
+
+	err := deleteTeam(client, template)(w, r)
+	assert.Nil(err)
+
+	assert.Equal(1, client.team.count)
+	assert.Equal(1, client.deleteTeam.count)
+	assert.Equal(getContext(r), client.deleteTeam.lastCtx)
+	assert.Equal(461, client.deleteTeam.lastTeamID)
+
+	assert.Equal(1, template.count)
+	assert.Equal(deleteTeamVars{
+		Path:           "/teams/delete/461",
+		Team:           client.team.data,
+		SuccessMessage: "The team \"Filing - Pool 5\" was deleted.",
+	}, template.lastVars)
+}
+
+func TestPostDeleteTeamClientError(t *testing.T) {
+	assert := assert.New(t)
+
+	client := &mockDeleteTeamClient{}
+	client.deleteTeam.err = sirius.ClientError("problem")
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("POST", "/teams/delete/461", nil)
+
+	err := deleteTeam(client, template)(w, r)
+	assert.Nil(err)
+
+	assert.Equal(1, client.team.count)
+	assert.Equal(1, client.deleteTeam.count)
+
+	assert.Equal(1, template.count)
+	assert.Equal("page", template.lastName)
+	assert.Equal(deleteTeamVars{
+		Path: "/teams/delete/461",
+		Team: client.team.data,
+		Errors: sirius.ValidationErrors{
+			"": {
+				"": "problem",
+			},
+		},
+	}, template.lastVars)
+}
+
+func TestPostDeleteTeamOtherError(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedErr := errors.New("oops")
+	client := &mockDeleteTeamClient{}
+	client.deleteTeam.err = expectedErr
+	template := &mockTemplate{}
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("POST", "/teams/delete/461", nil)
+
+	err := deleteTeam(client, template)(w, r)
+	assert.Equal(expectedErr, err)
+
+	assert.Equal(1, client.team.count)
+	assert.Equal(1, client.deleteTeam.count)
+	assert.Equal(0, template.count)
+}
+
+func TestPutDeleteTeam(t *testing.T) {
+	assert := assert.New(t)
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("PUT", "/teams/delete/461", nil)
+
+	err := deleteTeam(nil, nil)(w, r)
+	assert.Equal(StatusError(http.StatusMethodNotAllowed), err)
+}

--- a/internal/server/edit_team.go
+++ b/internal/server/edit_team.go
@@ -21,6 +21,7 @@ type editTeamVars struct {
 	Team            sirius.Team
 	TeamTypeOptions []sirius.RefDataTeamType
 	CanEditTeamType bool
+	CanDeleteTeam   bool
 	Success         bool
 	Errors          sirius.ValidationErrors
 }
@@ -44,6 +45,11 @@ func editTeam(client EditTeamClient, tmpl Template) Handler {
 			return err
 		}
 
+		canDeleteTeam, err := client.HasPermission(ctx, "v1-teams", "delete")
+		if err != nil {
+			return err
+		}
+
 		teamTypes, err := client.TeamTypes(ctx)
 		if err != nil {
 			return err
@@ -55,6 +61,7 @@ func editTeam(client EditTeamClient, tmpl Template) Handler {
 			Team:            team,
 			TeamTypeOptions: teamTypes,
 			CanEditTeamType: canEditTeamType,
+			CanDeleteTeam:   canDeleteTeam,
 		}
 
 		switch r.Method {

--- a/internal/server/edit_team.go
+++ b/internal/server/edit_team.go
@@ -12,7 +12,7 @@ type EditTeamClient interface {
 	Team(sirius.Context, int) (sirius.Team, error)
 	EditTeam(sirius.Context, sirius.Team) error
 	TeamTypes(sirius.Context) ([]sirius.RefDataTeamType, error)
-	HasPermission(sirius.Context, string, string) (bool, error)
+	GetMyPermissions(sirius.Context) (sirius.PermissionSet, error)
 }
 
 type editTeamVars struct {
@@ -40,15 +40,13 @@ func editTeam(client EditTeamClient, tmpl Template) Handler {
 			return err
 		}
 
-		canEditTeamType, err := client.HasPermission(ctx, "team", "post")
+		myPermissions, err := client.GetMyPermissions(ctx)
 		if err != nil {
 			return err
 		}
 
-		canDeleteTeam, err := client.HasPermission(ctx, "v1-teams", "delete")
-		if err != nil {
-			return err
-		}
+		canEditTeamType := myPermissions.HasPermission("team", "post")
+		canDeleteTeam := myPermissions.HasPermission("v1-teams", "delete")
 
 		teamTypes, err := client.TeamTypes(ctx)
 		if err != nil {

--- a/internal/server/edit_team_test.go
+++ b/internal/server/edit_team_test.go
@@ -426,7 +426,7 @@ func TestPostEditTeamRefDataError(t *testing.T) {
 	assert.Equal(0, template.count)
 }
 
-func TestPostEditTeamGetyPermissionsError(t *testing.T) {
+func TestPostEditTeamGetPermissionsError(t *testing.T) {
 	assert := assert.New(t)
 
 	client := &mockEditTeamClient{}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,6 +19,7 @@ type Client interface {
 	AddUserClient
 	AllowRolesClient
 	ChangePasswordClient
+	DeleteTeamClient
 	DeleteUserClient
 	EditMyDetailsClient
 	EditTeamClient
@@ -69,6 +70,11 @@ func New(logger Logger, client Client, templates map[string]*template.Template, 
 		wrap(
 			allowRoles(client, "System Admin", "Manager")(
 				editTeam(client, templates["team-edit.gotmpl"]))))
+
+	mux.Handle("/teams/delete/",
+		wrap(
+			systemAdminOnly(
+				deleteTeam(client, templates["team-delete.gotmpl"]))))
 
 	mux.Handle("/teams/add-member/",
 		wrap(

--- a/internal/sirius/delete_team.go
+++ b/internal/sirius/delete_team.go
@@ -1,0 +1,38 @@
+package sirius
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+func (c *Client) DeleteTeam(ctx Context, teamID int) error {
+	req, err := c.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/teams/%d", teamID), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return ErrUnauthorized
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		var v struct {
+			Detail string `json:"detail"`
+		}
+
+		if err := json.NewDecoder(resp.Body).Decode(&v); err == nil {
+			return ClientError(v.Detail)
+		}
+
+		return newStatusError(resp)
+	}
+
+	return nil
+}

--- a/internal/sirius/delete_team_test.go
+++ b/internal/sirius/delete_team_test.go
@@ -1,0 +1,123 @@
+package sirius
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pact-foundation/pact-go/dsl"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteTeam(t *testing.T) {
+	pact := &dsl.Pact{
+		Consumer:          "sirius-user-management",
+		Provider:          "sirius",
+		Host:              "localhost",
+		PactFileWriteMode: "merge",
+		LogDir:            "../../logs",
+		PactDir:           "../../pacts",
+	}
+	defer pact.Teardown()
+
+	testCases := []struct {
+		name          string
+		setup         func()
+		teamID        int
+		cookies       []*http.Cookie
+		expectedError error
+	}{
+		{
+			name:   "OK",
+			teamID: 461,
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("A team that can be deleted").
+					UponReceiving("A request to delete the team").
+					WithRequest(dsl.Request{
+						Method: http.MethodDelete,
+						Path:   dsl.String("/api/v1/teams/461"),
+						Headers: dsl.MapMatcher{
+							"X-XSRF-TOKEN":        dsl.String("abcde"),
+							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
+							"OPG-Bypass-Membrane": dsl.String("1"),
+						},
+					}).
+					WillRespondWith(dsl.Response{
+						Status: http.StatusNoContent,
+					})
+			},
+			cookies: []*http.Cookie{
+				{Name: "XSRF-TOKEN", Value: "abcde"},
+				{Name: "Other", Value: "other"},
+			},
+		},
+
+		{
+			name:   "Unauthorized",
+			teamID: 461,
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("A team that can be deleted").
+					UponReceiving("A request to delete the team without cookies").
+					WithRequest(dsl.Request{
+						Method: http.MethodDelete,
+						Path:   dsl.String("/api/v1/teams/461"),
+						Headers: dsl.MapMatcher{
+							"OPG-Bypass-Membrane": dsl.String("1"),
+						},
+					}).
+					WillRespondWith(dsl.Response{
+						Status: http.StatusUnauthorized,
+					})
+			},
+			expectedError: ErrUnauthorized,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+
+			assert.Nil(t, pact.Verify(func() error {
+				client, _ := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
+
+				err := client.DeleteTeam(getContext(tc.cookies), tc.teamID)
+
+				assert.Equal(t, tc.expectedError, err)
+				return nil
+			}))
+		})
+	}
+}
+
+func TestDeleteTeamClientError(t *testing.T) {
+	s := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `{"detail":"oops"}`, http.StatusBadRequest)
+		}),
+	)
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	err := client.DeleteTeam(getContext(nil), 461)
+	assert.Equal(t, ClientError("oops"), err)
+}
+
+func TestDeleteTeamStatusError(t *testing.T) {
+	s := teapotServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	err := client.DeleteTeam(getContext(nil), 461)
+	assert.Equal(t, StatusError{
+		Code:   http.StatusTeapot,
+		URL:    s.URL + "/api/v1/teams/461",
+		Method: http.MethodDelete,
+	}, err)
+}

--- a/internal/sirius/has_permission_test.go
+++ b/internal/sirius/has_permission_test.go
@@ -127,7 +127,7 @@ func TestHasPermissionStatusError(t *testing.T) {
 }
 
 func TestPermissionSetChecksPermission(t *testing.T) {
-	permissions := permissionSet{
+	permissions := PermissionSet{
 		"user": {
 			Permissions: []string{"GET", "PATCH"},
 		},

--- a/prototype/app/views/teams/delete.html
+++ b/prototype/app/views/teams/delete.html
@@ -1,0 +1,35 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Delete Allocations - (Supervision) team
+{% endblock %}
+
+{% block beforeContent %}
+  <a class="govuk-back-link" href="/teams/edit">Back</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Delete Allocations - (Supervision) team</h1>
+
+      <p>Are you sure you want to delete the team <strong>Allocations - (Supervision)</strong>?</p>
+
+      <form class="form" action="/teams" method="post">
+
+        {{ govukButton({
+          text: "Delete team",
+          classes: "govuk-button--warning"
+        }) }}
+
+        {{ govukButton({
+          element: "a",
+          href: "/teams/edit",
+          text: "Cancel",
+          classes: "govuk-button--secondary"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/prototype/app/views/teams/edit.html
+++ b/prototype/app/views/teams/edit.html
@@ -1,5 +1,7 @@
 {% extends "layout.html" %}
 
+{% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
+
 {% block pageTitle %}
   Edit Allocations - (Supervision) team - Sirius
 {% endblock %}
@@ -9,10 +11,21 @@
 {% endblock %}
 
 {% block content %}
+  {{ mojPageHeaderActions({
+    heading: {
+      html: '<h1 class="govuk-heading-xl">Edit Allocations - (Supervision) team</h1>'
+    },
+    items: [
+      {
+        text: 'Delete team',
+        href: '/teams/delete',
+        classes: 'govuk-button--warning'
+      }
+    ]
+  }) }}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Edit Allocations - (Supervision) team</h1>
-
       <form class="form" action="/teams" method="post">
 
         {{ govukInput({

--- a/web/template/team-delete.gotmpl
+++ b/web/template/team-delete.gotmpl
@@ -1,0 +1,39 @@
+{{ template "page" . }}
+
+{{ define "backlink" }}
+  {{ if not .SuccessMessage }}
+    <a class="govuk-back-link" href="{{ prefix (printf "/teams/edit/%d" .Team.ID) }}">Back</a>
+  {{ end }}
+{{ end }}
+
+{{ define "title" }}
+  Delete {{ .Team.DisplayName }}
+{{ end }}
+
+{{ define "main" }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ template "error-summary" .Errors }}
+
+      {{ if .SuccessMessage }}
+        <h1 class="govuk-heading-xl">Team deleted</h1>
+
+        <p class="govuk-body">{{ .SuccessMessage }}</p>
+
+        <a href="{{ prefix "/teams" }}" class="govuk-button">Continue</a>
+      {{ else }}
+        <h1 class="govuk-heading-xl">Delete {{ .Team.DisplayName }} team</h1>
+
+        <p class="govuk-body">
+          Are you sure you want to delete the team <strong>{{ .Team.DisplayName }}</strong>?
+        </p>
+
+        <form class="form" action="" method="post">
+          <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}" />
+          <button type="submit" class="govuk-button govuk-button--warning govuk-!-margin-right-1">Delete team</button>
+          <a href="{{ prefix (printf "/teams/edit/%d" .Team.ID) }}" class="govuk-button govuk-button--secondary">Cancel</a>
+        </form>
+      {{ end }}
+    </div>
+  </div>
+{{ end }}

--- a/web/template/team-edit.gotmpl
+++ b/web/template/team-edit.gotmpl
@@ -16,11 +16,31 @@
       {{ if .Success }}
         {{ template "success-banner" (printf "You have successfully edited %s." .Team.DisplayName) }}
       {{ end }}
+    </div>
+  </div>
 
+  <div class="moj-page-header-actions">
+    <div class="moj-page-header-actions__title">
       <h1 class="govuk-heading-xl">Edit {{ .Team.DisplayName }}</h1>
+    </div>
+    <div class="moj-page-header-actions__actions">
+      <div class="moj-button-menu">
+        <div class="moj-button-menu__wrapper">
+          {{ if .CanDeleteTeam }}
+            <a href="{{ prefix (printf "/teams/delete/%d" .Team.ID) }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--warning moj-page-header-actions__action" data-module="govuk-button">
+              Delete team
+            </a>
+          {{ end }}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <form class="form" action="" method="post">
         <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}" />
-        
+
         <div class="govuk-form-group {{ if .Errors.name }}govuk-form-group--error{{ end }}">
           <label class="govuk-label" for="f-name">
             Team name

--- a/web/template/team.gotmpl
+++ b/web/template/team.gotmpl
@@ -30,7 +30,7 @@
   {{ if .Team.Members }}
     <form action="{{ prefix (printf "/teams/remove-member/%d" .Team.ID) }}" method="POST">
       <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}" />
-      
+
       <button type="submit" class="govuk-button govuk-button--secondary">
         Remove selected from team
       </button>
@@ -49,8 +49,8 @@
               <th scope="row" class="govuk-table__header">
                 <div class="govuk-checkboxes govuk-checkboxes--small">
                   <div class="govuk-checkboxes__item">
-                    <input class="govuk-checkboxes__input" name="selected[]" type="checkbox" value="{{ .ID }}">
-                    <label class="govuk-label govuk-checkboxes__label">
+                    <input class="govuk-checkboxes__input" name="selected[]" type="checkbox" value="{{ .ID }}" id="f-select-user-{{ .ID }}">
+                    <label class="govuk-label govuk-checkboxes__label" for="f-select-user-{{ .ID }}">
                       <span class="govuk-visually-hidden">Select {{ .DisplayName }}</span>
                     </label>
                   </div>


### PR DESCRIPTION
Pretty much the same as deleting users, although I had to hide the button between the `v1-teams:delete` permission because managers also have access to this page.

I fixed the URLs for testing page accessibility, which identified one accessibility problem I fixed and [a known issue with the design system](https://design-system.service.gov.uk/components/radios/#known-issues) which I covered up.

NB: You can URL-hack to edit and delete an already-deleted team, which we should fix (by returning 410 when a team has been deleted).