### PR TITLE
VEGA-641: Use v1 endpoint to update teams

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 node_modules
-prototype
 cypress/screenshots
 cypress/videos

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,2 +1,0 @@
-paths-ignore:
-  - prototype

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,6 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
-        config-file: ./.github/codeql/codeql-config.yml
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.

--- a/cypress/integration/edit_team.spec.js
+++ b/cypress/integration/edit_team.spec.js
@@ -9,14 +9,14 @@ describe("Edit a team", () => {
         cy.get("#f-name").should("have.value", "Cool Team");
         cy.get("#f-service-conditional").should("be.checked");
         cy.get("#f-service-conditional-2").should("not.be.checked");
-        cy.get("#f-teamType").should("have.value", "ALLOCATIONS");
+        cy.get("#f-type").should("have.value", "ALLOCATIONS");
         cy.get("#f-phoneNumber").should("have.value", "01818118181");
         cy.get("#f-email").should("have.value", "coolteam@opgtest.com");
     });
 
     it("allows me to change the team's details", () => {
         cy.get("#f-name").clear().type("Another team");
-        cy.get("#f-teamType").select("ALLOCATIONS");
+        cy.get("#f-type").select("ALLOCATIONS");
         cy.get("#f-phoneNumber").clear().type("03573953");
         cy.get("#f-email").clear().type("other.team@opgtest.com");
         cy.get("button[type=submit]").click();

--- a/internal/sirius/edit_team.go
+++ b/internal/sirius/edit_team.go
@@ -36,7 +36,7 @@ func (c *Client) EditTeam(ctx Context, team Team) error {
 
 	requestURL := fmt.Sprintf("/api/v1/teams/%d", team.ID)
 
-	req, err := c.newRequest(ctx, http.MethodPatch, requestURL, &body)
+	req, err := c.newRequest(ctx, http.MethodPut, requestURL, &body)
 	if err != nil {
 		return err
 	}

--- a/internal/sirius/edit_team.go
+++ b/internal/sirius/edit_team.go
@@ -16,9 +16,9 @@ type editTeamRequest struct {
 }
 
 func (c *Client) EditTeam(ctx Context, team Team) error {
-	memberIds := []int{}
-	for _, member := range team.Members {
-		memberIds = append(memberIds, member.ID)
+	memberIDs := make([]int, len(team.Members))
+	for i, member := range team.Members {
+		memberIDs[i] = member.ID
 	}
 
 	var body bytes.Buffer
@@ -27,7 +27,7 @@ func (c *Client) EditTeam(ctx Context, team Team) error {
 		Email:       team.Email,
 		PhoneNumber: team.PhoneNumber,
 		Type:        team.Type,
-		MemberIds:   memberIds,
+		MemberIds:   memberIDs,
 	})
 
 	if err != nil {

--- a/internal/sirius/edit_team_test.go
+++ b/internal/sirius/edit_team_test.go
@@ -12,7 +12,7 @@ import (
 type editTeamErrorsResponse struct {
 	Errors *struct {
 		TeamType *struct {
-			TeamTypeAlreadyInUse string `json:"teamTypeAlreadyInUse" pact:"example=Invalid team type"`
+			Error string `json:"error" pact:"example=Invalid team type"`
 		} `json:"type"`
 	} `json:"validation_errors"`
 }
@@ -90,9 +90,6 @@ func TestEditTeam(t *testing.T) {
 						ID:    23,
 						Email: "someone@opgtest.com",
 					},
-					{
-						ID: 87,
-					},
 				},
 			},
 			setup: func() {
@@ -114,7 +111,7 @@ func TestEditTeam(t *testing.T) {
 							"name":        "Test team with members",
 							"phoneNumber": "014729583920",
 							"type":        "INVESTIGATIONS",
-							"memberIds":   []int{23, 87},
+							"memberIds":   []int{23},
 						},
 					}).
 					WillRespondWith(dsl.Response{
@@ -204,7 +201,7 @@ func TestEditTeam(t *testing.T) {
 				return &ValidationError{
 					Errors: ValidationErrors{
 						"type": {
-							"teamTypeAlreadyInUse": "Invalid team type",
+							"error": "Invalid team type",
 						},
 					},
 				}

--- a/internal/sirius/edit_team_test.go
+++ b/internal/sirius/edit_team_test.go
@@ -81,7 +81,7 @@ func TestEditTeam(t *testing.T) {
 			name: "OKSendsMembers",
 			team: Team{
 				ID:          65,
-				DisplayName: "Test team",
+				DisplayName: "Test team with members",
 				Type:        "INVESTIGATIONS",
 				PhoneNumber: "014729583920",
 				Email:       "test.team@opgtest.com",
@@ -111,7 +111,7 @@ func TestEditTeam(t *testing.T) {
 						},
 						Body: map[string]interface{}{
 							"email":       "test.team@opgtest.com",
-							"name":        "Test team",
+							"name":        "Test team with members",
 							"phoneNumber": "014729583920",
 							"type":        "INVESTIGATIONS",
 							"memberIds":   []int{23, 87},
@@ -166,14 +166,14 @@ func TestEditTeam(t *testing.T) {
 			name: "Validation Errors",
 			team: Team{
 				ID:          65,
-				DisplayName: "Test team",
+				DisplayName: "Test duplicate finance team",
 				Type:        "FINANCE",
 			},
 			setup: func() {
 				pact.
 					AddInteraction().
 					Given("Supervision team with members exists").
-					UponReceiving("A request to edit the team with an non-unique type").
+					UponReceiving("A request to edit the team with a non-unique type").
 					WithRequest(dsl.Request{
 						Method: http.MethodPut,
 						Path:   dsl.String("/api/v1/teams/65"),
@@ -184,7 +184,7 @@ func TestEditTeam(t *testing.T) {
 							"Content-Type":        dsl.String("application/json"),
 						},
 						Body: map[string]interface{}{
-							"name":        "Test team",
+							"name":        "Test duplicate finance team",
 							"type":        "FINANCE",
 							"email":       "",
 							"phoneNumber": "",

--- a/internal/sirius/edit_team_test.go
+++ b/internal/sirius/edit_team_test.go
@@ -50,7 +50,7 @@ func TestEditTeam(t *testing.T) {
 					Given("A user and a team").
 					UponReceiving("A request to edit the team").
 					WithRequest(dsl.Request{
-						Method: http.MethodPatch,
+						Method: http.MethodPut,
 						Path:   dsl.String("/api/v1/teams/65"),
 						Headers: dsl.MapMatcher{
 							"X-XSRF-TOKEN":        dsl.String("abcde"),
@@ -101,7 +101,7 @@ func TestEditTeam(t *testing.T) {
 					Given("A user and a team").
 					UponReceiving("A request to edit the team with members").
 					WithRequest(dsl.Request{
-						Method: http.MethodPatch,
+						Method: http.MethodPut,
 						Path:   dsl.String("/api/v1/teams/65"),
 						Headers: dsl.MapMatcher{
 							"X-XSRF-TOKEN":        dsl.String("abcde"),
@@ -141,7 +141,7 @@ func TestEditTeam(t *testing.T) {
 					Given("A user and a team").
 					UponReceiving("A request to edit the team without cookies").
 					WithRequest(dsl.Request{
-						Method: http.MethodPatch,
+						Method: http.MethodPut,
 						Path:   dsl.String("/api/v1/teams/65"),
 						Headers: dsl.MapMatcher{
 							"OPG-Bypass-Membrane": dsl.String("1"),
@@ -175,7 +175,7 @@ func TestEditTeam(t *testing.T) {
 					Given("A user and a team").
 					UponReceiving("A request to edit the team with an non-unique type").
 					WithRequest(dsl.Request{
-						Method: http.MethodPatch,
+						Method: http.MethodPut,
 						Path:   dsl.String("/api/v1/teams/65"),
 						Headers: dsl.MapMatcher{
 							"X-XSRF-TOKEN":        dsl.String("abcde"),
@@ -238,6 +238,6 @@ func TestEditTeamStatusError(t *testing.T) {
 	assert.Equal(t, StatusError{
 		Code:   http.StatusTeapot,
 		URL:    s.URL + "/api/v1/teams/65",
-		Method: http.MethodPatch,
+		Method: http.MethodPut,
 	}, err)
 }

--- a/internal/sirius/edit_team_test.go
+++ b/internal/sirius/edit_team_test.go
@@ -47,7 +47,7 @@ func TestEditTeam(t *testing.T) {
 			setup: func() {
 				pact.
 					AddInteraction().
-					Given("A user and a team").
+					Given("Supervision team with members exists").
 					UponReceiving("A request to edit the team").
 					WithRequest(dsl.Request{
 						Method: http.MethodPut,
@@ -98,7 +98,7 @@ func TestEditTeam(t *testing.T) {
 			setup: func() {
 				pact.
 					AddInteraction().
-					Given("A user and a team").
+					Given("Supervision team with members exists").
 					UponReceiving("A request to edit the team with members").
 					WithRequest(dsl.Request{
 						Method: http.MethodPut,
@@ -138,7 +138,7 @@ func TestEditTeam(t *testing.T) {
 			setup: func() {
 				pact.
 					AddInteraction().
-					Given("A user and a team").
+					Given("Supervision team with members exists").
 					UponReceiving("A request to edit the team without cookies").
 					WithRequest(dsl.Request{
 						Method: http.MethodPut,
@@ -172,7 +172,7 @@ func TestEditTeam(t *testing.T) {
 			setup: func() {
 				pact.
 					AddInteraction().
-					Given("A user and a team").
+					Given("Supervision team with members exists").
 					UponReceiving("A request to edit the team with an non-unique type").
 					WithRequest(dsl.Request{
 						Method: http.MethodPut,

--- a/web/template/team-edit.gotmpl
+++ b/web/template/team-edit.gotmpl
@@ -55,13 +55,13 @@
           <input class="govuk-input {{ if .Errors.name }}govuk-input--error{{ end }}" id="f-name" name="name" type="text" value="{{ .Team.DisplayName }}">
         </div>
 
-        <div class="govuk-form-group {{ if .Errors.teamType }}govuk-form-group--error{{ end }}">
+        <div class="govuk-form-group {{ if .Errors.type }}govuk-form-group--error{{ end }}">
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend">
               Team service
             </legend>
 
-            {{ range .Errors.teamType }}
+            {{ range .Errors.type }}
               <span class="govuk-error-message">
                 <span class="govuk-visually-hidden">Error:</span> {{ . }}
               </span>
@@ -77,10 +77,10 @@
 
               <div class="govuk-radios__conditional {{ if eq .Team.Type "" }}govuk-radios__conditional--hidden{{ end }}" id="conditional-f-service-conditional">
                 <div class="govuk-form-group">
-                  <label class="govuk-label" for="f-teamType">
+                  <label class="govuk-label" for="f-type">
                     Supervision team type
                   </label>
-                  <select class="govuk-select {{ if .Errors.teamType }}govuk-select--error{{ end }}" id="f-teamType" name="supervision-type" {{ if not .CanEditTeamType }}disabled{{ end }}>
+                  <select class="govuk-select {{ if .Errors.type }}govuk-select--error{{ end }}" id="f-type" name="supervision-type" {{ if not .CanEditTeamType }}disabled{{ end }}>
                     {{ range .TeamTypeOptions }}
                       <option value="{{ .Handle }}" {{ if eq $.Team.Type .Handle }}selected{{ end }}>{{ .Label }}</option>
                     {{ end }}


### PR DESCRIPTION
Uses `PATCH /api/v1/teams/:id` rather than `PUT /api/team/:id`, which provides enhanced validation and testing (ministryofjustice/opg-sirius#4288).

Despite the endpoint being PATCH and accepting partial objects, we send the entire thing across every time because of how the `EditTeam` interface has already been designed. Teams are changed infrequently enough that this isn't really a concern.

I also stripped out some old references to the prototype directory.