### PR TITLE
Create gosec.yml

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,0 +1,19 @@
+name: Run Gosec
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: ./...

--- a/docker/pact-stub/pact_stub.go
+++ b/docker/pact-stub/pact_stub.go
@@ -35,6 +35,12 @@ func readInteractions(dir string) ([]Interaction, error) {
 	}
 
 	for _, path := range paths {
+		path = filepath.Clean(path)
+
+		if !strings.HasPrefix(path, "pacts") {
+			return nil, fmt.Errorf("invalid interaction path")
+		}
+
 		file, err := os.Open(path)
 		if err != nil {
 			return nil, fmt.Errorf("opening %s: %w", path, err)

--- a/docker/pact-stub/pact_stub.go
+++ b/docker/pact-stub/pact_stub.go
@@ -35,13 +35,7 @@ func readInteractions(dir string) ([]Interaction, error) {
 	}
 
 	for _, path := range paths {
-		path = filepath.Clean(path)
-
-		if !strings.HasPrefix(path, "pacts") {
-			return nil, fmt.Errorf("invalid interaction path")
-		}
-
-		file, err := os.Open(path)
+		file, err := os.Open(filepath.Clean(path))
 		if err != nil {
 			return nil, fmt.Errorf("opening %s: %w", path, err)
 		}

--- a/docker/pact-stub/pact_stub.go
+++ b/docker/pact-stub/pact_stub.go
@@ -45,6 +45,7 @@ func readInteractions(dir string) ([]Interaction, error) {
 		if err != nil {
 			return nil, fmt.Errorf("opening %s: %w", path, err)
 		}
+		/* #nosec */
 		defer file.Close()
 
 		var v Pacts


### PR DESCRIPTION
Adds `gosec` to build pipeline, and addresses two errors it spotted. First, it uses `FilePath.clean` to stop malicious paths breaking out of the base directory (this isn't really a going concern on the container, but I wanted to see the impact of fixing an issue). It then ignores the second error, because it's only really relevant when writing files (which we are not).