### PR TITLE
VEGA-633: Use v1 Roles API

### DIFF
--- a/internal/sirius/roles.go
+++ b/internal/sirius/roles.go
@@ -7,33 +7,31 @@ import (
 )
 
 func (c *Client) Roles(ctx Context) ([]string, error) {
-	var v struct {
-		Data []string `json:"data"`
-	}
+	var v []string
 
-	req, err := c.newRequest(ctx, http.MethodGet, "/api/role", nil)
+	req, err := c.newRequest(ctx, http.MethodGet, "/api/v1/roles", nil)
 	if err != nil {
-		return v.Data, err
+		return v, err
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return v.Data, err
+		return v, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return v.Data, ErrUnauthorized
+		return v, ErrUnauthorized
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return v.Data, newStatusError(resp)
+		return v, newStatusError(resp)
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&v)
 
 	var roles []string
-	for _, role := range v.Data {
+	for _, role := range v {
 		if role != "COP User" && role != "OPG User" {
 			roles = append(roles, role)
 		}

--- a/internal/sirius/roles_test.go
+++ b/internal/sirius/roles_test.go
@@ -36,7 +36,7 @@ func TestRoles(t *testing.T) {
 					UponReceiving("A request for roles").
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
-						Path:   dsl.String("/api/role"),
+						Path:   dsl.String("/api/v1/roles"),
 						Headers: dsl.MapMatcher{
 							"X-XSRF-TOKEN":        dsl.String("abcde"),
 							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
@@ -45,9 +45,7 @@ func TestRoles(t *testing.T) {
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
-						Body: dsl.Like(map[string]interface{}{
-							"data": dsl.EachLike("System Admin", 1),
-						}),
+						Body:   dsl.EachLike("System Admin", 1),
 					})
 			},
 			cookies: []*http.Cookie{
@@ -66,7 +64,7 @@ func TestRoles(t *testing.T) {
 					UponReceiving("A request for roles without cookies").
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
-						Path:   dsl.String("/api/role"),
+						Path:   dsl.String("/api/v1/roles"),
 						Headers: dsl.MapMatcher{
 							"OPG-Bypass-Membrane": dsl.String("1"),
 						},
@@ -105,7 +103,7 @@ func TestRolesStatusError(t *testing.T) {
 	_, err := client.Roles(getContext(nil))
 	assert.Equal(t, StatusError{
 		Code:   http.StatusTeapot,
-		URL:    s.URL + "/api/role",
+		URL:    s.URL + "/api/v1/roles",
 		Method: http.MethodGet,
 	}, err)
 }


### PR DESCRIPTION
Switches `roles` service to use the new v1 API added by [opg-sirius#4581](https://github.com/ministryofjustice/opg-sirius/pull/4581)