### PR TITLE
VEGA-745: Escape query string in API request

### DIFF
--- a/internal/sirius/search_users.go
+++ b/internal/sirius/search_users.go
@@ -3,6 +3,7 @@ package sirius
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 )
@@ -44,7 +45,7 @@ func (c *Client) SearchUsers(ctx Context, search string) ([]User, error) {
 		return nil, ClientError("Search term must be at least three characters")
 	}
 
-	req, err := c.newRequest(ctx, http.MethodGet, "/api/v1/search/users?query="+search, nil)
+	req, err := c.newRequest(ctx, http.MethodGet, "/api/v1/search/users?query="+url.QueryEscape(search), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sirius/search_users_test.go
+++ b/internal/sirius/search_users_test.go
@@ -128,6 +128,20 @@ func TestSearchUsersStatusError(t *testing.T) {
 	}, err)
 }
 
+func TestSearchUsersEscapesQuery(t *testing.T) {
+	s := teapotServer()
+	defer s.Close()
+
+	client, _ := NewClient(http.DefaultClient, s.URL)
+
+	_, err := client.SearchUsers(getContext(nil), "Maria Fernández")
+	assert.Equal(t, StatusError{
+		Code:   http.StatusTeapot,
+		URL:    s.URL + "/api/v1/search/users?query=Maria+Fern%C3%A1ndez",
+		Method: http.MethodGet,
+	}, err)
+}
+
 func TestSearchUsersTooShort(t *testing.T) {
 	client, _ := NewClient(http.DefaultClient, "")
 


### PR DESCRIPTION
This ensures we send a valid HTTP request, and specifically fixes an [nginx bug](https://trac.nginx.org/nginx/ticket/196) which causes requests with ` H` in the query to immediately fails as 400.