### PR TITLE
Run CodeQL on merge commit

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,11 +36,6 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1


### PR DESCRIPTION
When GitHub Actions runs on a pull request, it creates a merge commit with the latest changes from the source branch.

We used to run `checkout HEAD^2` to go _back_ and test the latest commit on the branch, but CodeQL now recommends against this and instead advises testing the merge commit.

This helps identify issues caused by two PRs created at the same time.