### PR TITLE
VEGA-782: Use Veracode uploadandscan to scan pushes to build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+name: Main Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  scan:
+    name: Run Security Scan
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - run: go mod vendor
+    - name: Build Veracode Package
+      run: |
+        mkdir package
+        cp -r internal package
+        cp -r vendor package
+        cp go.mod package
+        cp go.sum package
+        cp main.go package
+        cp main_test.go package
+        zip -r package.zip package
+
+    - name: Upload to Veracode and scan
+      uses: veracode/veracode-uploadandscan-action@master
+      with:
+        appname: 'opg-sirius-user-management'
+        filepath: './package.zip'
+        vid: '${{ secrets.VERACODE_API_ID }}'
+        vkey: '${{ secrets.VERACODE_API_KEY }}'


### PR DESCRIPTION
This is a longer process than pipeline scanning, and only one scan can run at any one time, so it should only be run on merges to main.

It creates a zip file [based on Veracode's requirements](https://help.veracode.com/r/compilation_go), uploads it, scans it and stores the results in Veracode.

Upload and scan runs asynchronously and shows the results in Veracode's UI (it doesn't block builds nor show up in GitHub's Security panel). Successes and failures will be emailed to... users...