### PR TITLE
Configure branch name for dependabot JS updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,14 @@ updates:
       timezone: "Europe/London"
     pull-request-branch-name:
       separator: "-"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    allow:
+      - dependency-type: "production"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+      timezone: "Europe/London"
+    pull-request-branch-name:
+      separator: "-"


### PR DESCRIPTION
When dependabot submits security updates, we want it to use the `-` separator in PR branches so they can be validly tagged by ECR.

We can only specify this by adding configuration to `dependabot.yml`. In doing so we have to switch from security updates to *all* updates.

I've limited dependabot to production dependencies (i.e. not `devDependencies`) to reduce the noise, because we were previously overwhelmed by updates to build packages. We will however *still get security updates for dev dependencies*.