### PR TITLE
Use org keys for Veracode upload and scan

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Main Workflow
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Main Workflow
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 
@@ -30,5 +30,5 @@ jobs:
       with:
         appname: 'opg-sirius-user-management'
         filepath: './package.zip'
-        vid: '${{ secrets.VERACODE_API_ID }}'
-        vkey: '${{ secrets.VERACODE_API_KEY }}'
+        vid: '${{ secrets.CYBERSECURITY_VERACODE_API_ID }}'
+        vkey: '${{ secrets.CYBERSECURITY_VERACODE_API_KEY }}'


### PR DESCRIPTION
There are organisation-level keys available so that we don't need to manage our own. Use them instead of repo-specific keys.