### PR TITLE
Alter pipeline for dependabot PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,7 @@ jobs:
     name: "Build & Push Containers"
     runs-on: ubuntu-latest
     needs: ['test', 'lint', 'acceptance-test', 'cypress']
+    if: github.actor != 'dependabot'
     outputs:
       branch: ${{ steps.set-outputs.outputs.branch }}
       tag: ${{ steps.bump_version.outputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,12 +68,21 @@ jobs:
               echo "::set-output name=TAG::${{github.sha}}"
           fi
       - name: Publish pacts
+        if: github.actor != 'dependabot[bot]'
         env:
           PACT_DIR: ./pacts
           PACT_BROKER_URL: https://pact-broker.api.opg.service.justice.gov.uk
           PACT_BROKER_USERNAME: admin
           PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
         run: PACT_TAG=${{ github.head_ref }} PACT_CONSUMER_VERSION=${{ steps.pact_tag.outputs.TAG }} go run internal/pact/publish.go
+      - name: Compare pacts
+        if: github.actor == 'dependabot[bot]'
+        env:
+          PACT_DIR: ./pacts
+          PACT_BROKER_URL: https://pact-broker.api.opg.service.justice.gov.uk
+        run: |
+          curl ${PACT_BROKER_URL}/pacts/provider/sirius/consumer/sirius-user-management/latest > /tmp/latest-pact.json
+          (diff <(jq --sort-keys . ${PACT_DIR}/sirius-user-management-sirius.json) <(jq --sort-keys . /tmp/latest-pact.json) || true) | (! grep '<')
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
Dependabot doesn't have access to GitHub Actions secrets, so cannot perform all of the steps of the current pipeline. Specifically, it cannot write to Pact broker or push to AWS.

This change alters the pipeline for dependabot PRs. Instead of writing to the broker, it pulls the latest copy of the contract and diffs against it. It passes if the local contract has not added or changed anything compared to latest (we allow it to remove things, since the remote has some extra data).

It skips pushing to AWS entirely, since there is generally no need for it. If a dependency upgrade requires deployment, we can cherry-pick the commit onto a dev-authored PR and run the original pipeline in full.