### PR TITLE
Cache docker images in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,25 @@ defaults:
     shell: bash
 
 jobs:
+  build:
+    name: Build User Management
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache Images
+        uses: actions/cache@v2
+        with:
+          path: /tmp/images
+          key: ${{ runner.os }}-images-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER
+      - name: Build Images
+        run: |
+          docker-compose -f docker/docker-compose.ci.yml build --parallel
+          mkdir -p /tmp/images
+          docker save -o /tmp/images/app.tar docker_app:latest
+          docker save -o /tmp/images/pact-stub.tar docker_pact-stub:latest
+          docker save -o /tmp/images/puppeteer.tar docker_puppeteer:latest
+          docker save -o /tmp/images/cypress.tar docker_cypress:latest
+
   test:
     name: Test User Management
     runs-on: ubuntu-latest
@@ -98,9 +117,16 @@ jobs:
   acceptance-test:
     name: Acceptance Testing
     runs-on: ubuntu-latest
-    needs: test
+    needs:
+      - build
+      - test
     steps:
       - uses: actions/checkout@v2
+      - name: Cache Images
+        uses: actions/cache@v2
+        with:
+          path: /tmp/images
+          key: ${{ runner.os }}-images-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER
       - name: Download Artifacts
         uses: actions/download-artifact@v2
         with:
@@ -111,6 +137,12 @@ jobs:
           docker container create --name temp -v pacts_data:/root hello-world
           docker cp ./pacts/ignored-ignored.json temp:/root/ignored-ignored.json
           docker cp ./pacts/sirius-user-management-sirius.json temp:/root/sirius-user-management-sirius.json
+
+      - name: Restore images
+        run: |
+          docker load -i /tmp/images/app.tar
+          docker load -i /tmp/images/pact-stub.tar
+          docker load -i /tmp/images/puppeteer.tar
 
       - name: Run pa11y
         run: |
@@ -123,9 +155,16 @@ jobs:
   cypress:
     name: Cypress
     runs-on: ubuntu-latest
-    needs: test
+    needs:
+      - build
+      - test
     steps:
       - uses: actions/checkout@v2
+      - name: Cache Images
+        uses: actions/cache@v2
+        with:
+          path: /tmp/images
+          key: ${{ runner.os }}-images-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER
       - name: Download Artifacts
         uses: actions/download-artifact@v2
         with:
@@ -136,11 +175,18 @@ jobs:
           docker container create --name temp -v pacts_data:/root hello-world
           docker cp ./pacts/ignored-ignored.json temp:/root/ignored-ignored.json
           docker cp ./pacts/sirius-user-management-sirius.json temp:/root/sirius-user-management-sirius.json
+
+      - name: Restore images
+        run: |
+          docker load -i /tmp/images/app.tar
+          docker load -i /tmp/images/pact-stub.tar
+          docker load -i /tmp/images/cypress.tar
+
       - name: Run cypress
         run: |
           docker-compose -f docker/docker-compose.ci.yml run cypress
 
-  build:
+  push:
     name: "Build & Push Containers"
     runs-on: ubuntu-latest
     needs: ['test', 'lint', 'acceptance-test', 'cypress']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
   push:
     name: "Build & Push Containers"
     runs-on: ubuntu-latest
-    needs: ['test', 'lint', 'acceptance-test', 'cypress']
+    needs: ['build', 'test', 'lint', 'acceptance-test', 'cypress']
     outputs:
       branch: ${{ steps.set-outputs.outputs.branch }}
       tag: ${{ steps.bump_version.outputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,10 @@ jobs:
           key: ${{ runner.os }}-images-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER
       - name: Build Images
         run: |
-          docker-compose -f docker/docker-compose.ci.yml build --parallel
+          docker-compose -f docker/docker-compose.ci.yml build --parallel app pact-stub
           mkdir -p /tmp/images
           docker save -o /tmp/images/app.tar docker_app:latest
           docker save -o /tmp/images/pact-stub.tar docker_pact-stub:latest
-          docker save -o /tmp/images/puppeteer.tar docker_puppeteer:latest
-          docker save -o /tmp/images/cypress.tar docker_cypress:latest
 
   test:
     name: Test User Management
@@ -142,7 +140,6 @@ jobs:
         run: |
           docker load -i /tmp/images/app.tar
           docker load -i /tmp/images/pact-stub.tar
-          docker load -i /tmp/images/puppeteer.tar
 
       - name: Run pa11y
         run: |
@@ -180,7 +177,6 @@ jobs:
         run: |
           docker load -i /tmp/images/app.tar
           docker load -i /tmp/images/pact-stub.tar
-          docker load -i /tmp/images/cypress.tar
 
       - name: Run cypress
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/images
-          key: ${{ runner.os }}-images-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER
+          key: ${{ runner.os }}-images-${{ github.run_id }}-${{ github.run_number }}
       - name: Build Images
         run: |
           docker-compose -f docker/docker-compose.ci.yml build --parallel app pact-stub
@@ -124,7 +124,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/images
-          key: ${{ runner.os }}-images-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER
+          key: ${{ runner.os }}-images-${{ github.run_id }}-${{ github.run_number }}
       - name: Download Artifacts
         uses: actions/download-artifact@v2
         with:
@@ -161,7 +161,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/images
-          key: ${{ runner.os }}-images-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER
+          key: ${{ runner.os }}-images-${{ github.run_id }}-${{ github.run_number }}
       - name: Download Artifacts
         uses: actions/download-artifact@v2
         with:
@@ -203,9 +203,16 @@ jobs:
         id: extract_branch
       - uses: unfor19/install-aws-cli-action@v1
 
-      - name: Build Container
+      - name: Cache Images
+        uses: actions/cache@v2
+        with:
+          path: /tmp/images
+          key: ${{ runner.os }}-images-${{ github.run_id }}-${{ github.run_number }}
+
+      - name: Restore Image
         run: |
-          docker build --tag sirius-user-management:latest -f docker/sirius-user-management/Dockerfile .
+          docker load -i /tmp/images/app.tar
+          docker tag docker_app:latest sirius-user-management:latest
       - name: Scan
         run: |
           docker run --rm  -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy sirius-user-management:latest
@@ -253,7 +260,7 @@ jobs:
 
   push-tags:
     runs-on: ubuntu-latest
-    needs: build
+    needs: push
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
We currently build the `app` and `pact-stub` containers in multiple workflow jobs. This is a big waste of compute and slows down the workflow time.

This change instead builds both containers at the start of the workflow, stores them in the Actions' cache, and then reuses them in later jobs.

I looked at doing the same for the `cypress` and `puppeteer` images but there's no speed benefit since they're only used in one job each anyway. If we really wanted to speed them up, we could store them in ECR and pull rather than build.

This takes about three minutes off the build time ([before](https://github.com/ministryofjustice/opg-sirius-user-management/actions/runs/895748537), [after](https://github.com/ministryofjustice/opg-sirius-user-management/actions/runs/896333669)) 