### PR TITLE
Revert "Bump alpine from 3.14.0 to 3.14.1 in /docker/sirius-user-management"

### DIFF
--- a/docker/sirius-user-management/Dockerfile
+++ b/docker/sirius-user-management/Dockerfile
@@ -24,7 +24,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/opg-sirius-user-management
 
-FROM alpine:3.14.1
+FROM alpine:3.14.0
 
 WORKDIR /go/bin
 


### PR DESCRIPTION
Reverts ministryofjustice/opg-sirius-user-management#162