### PR TITLE
Remove XSRF token from GET form

### DIFF
--- a/internal/server/list_teams.go
+++ b/internal/server/list_teams.go
@@ -13,7 +13,6 @@ type ListTeamsClient interface {
 
 type listTeamsVars struct {
 	Path      string
-	XSRFToken string
 	Search    string
 	Teams     []sirius.Team
 }
@@ -51,7 +50,6 @@ func listTeams(client ListTeamsClient, tmpl Template) Handler {
 
 		vars := listTeamsVars{
 			Path:      r.URL.Path,
-			XSRFToken: ctx.XSRFToken,
 			Search:    search,
 			Teams:     teams,
 		}

--- a/web/template/teams.gotmpl
+++ b/web/template/teams.gotmpl
@@ -24,8 +24,6 @@
   <div class="govuk-form-group">
     <div class="moj-search">
       <form action="{{ prefix "/teams" }}" method="GET">
-        <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}" />
-
         <div class="govuk-form-group">
           <label class="govuk-label moj-search__label" for="f-search">
             Find a team


### PR DESCRIPTION
This was probably included as a copy-paste error, but it doesn't need to be passed into the request.