### PR TITLE
Pin colors to 1.4.0 #patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "sass-loader": "^10.0.2",
     "webpack": "^5.65.0",
     "webpack-cli": "^4.8.0"
+  },
+  "resolutions": {
+    "colors": "1.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1449,9 +1449,9 @@ colorette@^1.2.2:
   resolved "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
-colors@^1.1.2:
+colors@1.4.0, colors@^1.1.2:
   version "1.4.0"
-  resolved "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:


### PR DESCRIPTION
To ensure we avoid a security issue in >1.4.4.

Can be removed when the package is back under secure control, or our core dependencies stop using it.