### PR TITLE
Fix Pact tests by adding randomisation

### DIFF
--- a/internal/sirius/add_team_test.go
+++ b/internal/sirius/add_team_test.go
@@ -20,6 +20,8 @@ func TestAddTeam(t *testing.T) {
 	}
 	defer pact.Teardown()
 
+	teamNameSuffix := randomString(15)
+
 	testCases := []struct {
 		scenario      string
 		setup         func()
@@ -49,7 +51,7 @@ func TestAddTeam(t *testing.T) {
 						},
 						Body: map[string]interface{}{
 							"email":       "john.doe@example.com",
-							"name":        "testteam",
+							"name":        "testteam" + teamNameSuffix,
 							"phoneNumber": "0300456090",
 						},
 					}).
@@ -65,7 +67,7 @@ func TestAddTeam(t *testing.T) {
 				{Name: "Other", Value: "other"},
 			},
 			email:      "john.doe@example.com",
-			name:       "testteam",
+			name:       "testteam" + teamNameSuffix,
 			phone:      "0300456090",
 			teamType:   "",
 			expectedID: 123,
@@ -89,7 +91,7 @@ func TestAddTeam(t *testing.T) {
 						},
 						Body: map[string]interface{}{
 							"email":       "john.doe@example.com",
-							"name":        "supervisiontestteam",
+							"name":        "supervisiontestteam" + teamNameSuffix,
 							"phoneNumber": "0300456090",
 							"type":        "INVESTIGATIONS",
 						},
@@ -106,7 +108,7 @@ func TestAddTeam(t *testing.T) {
 				{Name: "Other", Value: "other"},
 			},
 			email:      "john.doe@example.com",
-			name:       "supervisiontestteam",
+			name:       "supervisiontestteam" + teamNameSuffix,
 			phone:      "0300456090",
 			teamType:   "INVESTIGATIONS",
 			expectedID: 123,

--- a/internal/sirius/add_user_test.go
+++ b/internal/sirius/add_user_test.go
@@ -28,6 +28,8 @@ func TestAddUser(t *testing.T) {
 	}
 	defer pact.Teardown()
 
+	userEmailSuffix := randomString(15)
+
 	testCases := []struct {
 		name          string
 		setup         func()
@@ -58,7 +60,7 @@ func TestAddUser(t *testing.T) {
 						Body: map[string]interface{}{
 							"firstname": "John",
 							"surname":   "Doe",
-							"email":     "john.doe@example.com",
+							"email":     "john.doe" + userEmailSuffix + "@example.com",
 							"roles":     []string{"COP User", "other1", "other2"},
 						},
 					}).
@@ -72,7 +74,7 @@ func TestAddUser(t *testing.T) {
 			},
 			firstName:    "John",
 			lastName:     "Doe",
-			email:        "john.doe@example.com",
+			email:        "john.doe" + userEmailSuffix + "@example.com",
 			organisation: "COP User",
 			roles:        []string{"other1", "other2"},
 		},

--- a/internal/sirius/edit_team_test.go
+++ b/internal/sirius/edit_team_test.go
@@ -28,6 +28,8 @@ func TestEditTeam(t *testing.T) {
 	}
 	defer pact.Teardown()
 
+	teamNameSuffix := randomString(15)
+
 	testCases := []struct {
 		name          string
 		setup         func()
@@ -39,7 +41,7 @@ func TestEditTeam(t *testing.T) {
 			name: "OK",
 			team: Team{
 				ID:          65,
-				DisplayName: "Test team",
+				DisplayName: "Test team" + teamNameSuffix,
 				Type:        "INVESTIGATIONS",
 				PhoneNumber: "014729583920",
 				Email:       "test.team@opgtest.com",
@@ -60,7 +62,7 @@ func TestEditTeam(t *testing.T) {
 						},
 						Body: map[string]interface{}{
 							"email":       "test.team@opgtest.com",
-							"name":        "Test team",
+							"name":        "Test team" + teamNameSuffix,
 							"phoneNumber": "014729583920",
 							"type":        "INVESTIGATIONS",
 							"memberIds":   []int{},
@@ -81,7 +83,7 @@ func TestEditTeam(t *testing.T) {
 			name: "OKSendsMembers",
 			team: Team{
 				ID:          65,
-				DisplayName: "Test team with members",
+				DisplayName: "Test team with members" + teamNameSuffix,
 				Type:        "INVESTIGATIONS",
 				PhoneNumber: "014729583920",
 				Email:       "test.team@opgtest.com",
@@ -108,7 +110,7 @@ func TestEditTeam(t *testing.T) {
 						},
 						Body: map[string]interface{}{
 							"email":       "test.team@opgtest.com",
-							"name":        "Test team with members",
+							"name":        "Test team with members" + teamNameSuffix,
 							"phoneNumber": "014729583920",
 							"type":        "INVESTIGATIONS",
 							"memberIds":   []int{23},

--- a/internal/sirius/random.go
+++ b/internal/sirius/random.go
@@ -1,0 +1,17 @@
+package sirius
+
+import "crypto/rand"
+
+const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+
+func randomString(n int) string {
+	bytes := make([]byte, n)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		panic(err)
+	}
+	for i, b := range bytes {
+		bytes[i] = letters[b%byte(len(letters))]
+	}
+	return string(bytes)
+}


### PR DESCRIPTION
To prevent "user/team already exists" errors, add randomisation to unique identifiers.

#patch