### PR TITLE
Don't expect Renovate to have permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,14 +83,14 @@ jobs:
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
-        if: ${{ always() && github.actor != 'dependabot[bot]' }}
+        if: ${{ always() && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
         with:
           check_name: "Unit Test Results"
           files: test-results/unit-tests.xml
 
       - name: Scan with SonarQube
         uses: sonarsource/sonarqube-scan-action@master
-        if: ${{ always() && github.actor != 'dependabot[bot]' }}
+        if: ${{ always() && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
@@ -106,7 +106,7 @@ jobs:
               echo "::set-output name=BRANCH::main"
           fi
       - name: Publish pacts
-        if: github.actor != 'dependabot[bot]'
+        if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
         run: |
           pact-broker publish ./pacts/sirius-user-management-sirius.json \
             --consumer-app-version ${{ steps.pact_tag.outputs.TAG }} \
@@ -115,7 +115,7 @@ jobs:
             --broker-username admin \
             --broker-password ${{ secrets.PACT_BROKER_PASSWORD }}
       - name: Compare pacts
-        if: github.actor == 'dependabot[bot]'
+        if: github.actor == 'dependabot[bot]' && github.actor != 'renovate[bot]'
         env:
           PACT_DIR: ./pacts
           PACT_BROKER_URL: https://pact-broker.api.opg.service.justice.gov.uk
@@ -207,7 +207,7 @@ jobs:
     name: "Build & Push Containers"
     runs-on: ubuntu-latest
     needs: ["build", "test", "lint", "acceptance-test", "cypress"]
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     outputs:
       branch: ${{ steps.set-outputs.outputs.branch }}
       tag: ${{ steps.bump_version.outputs.tag }}


### PR DESCRIPTION
It won't be able to publish results, run scans, push files; so  skip those steps like we do for renovate.

#patch