### PR TITLE
Use API user endpoints

### DIFF
--- a/internal/server/delete_user.go
+++ b/internal/server/delete_user.go
@@ -55,12 +55,8 @@ func deleteUser(client DeleteUserClient, tmpl Template) Handler {
 		if r.Method == http.MethodPost {
 			err := client.DeleteUser(ctx, id)
 
-			if _, ok := err.(sirius.ClientError); ok {
-				vars.Errors = sirius.ValidationErrors{
-					"": {
-						"": err.Error(),
-					},
-				}
+			if e, ok := err.(sirius.ValidationError); ok {
+				vars.Errors = e.Errors
 
 				w.WriteHeader(http.StatusBadRequest)
 			} else if err != nil {

--- a/internal/server/delete_user_test.go
+++ b/internal/server/delete_user_test.go
@@ -154,11 +154,15 @@ func TestPostDeleteUser(t *testing.T) {
 	}, template.lastVars)
 }
 
-func TestPostDeleteUserClientError(t *testing.T) {
+func TestPostDeleteUserValidationError(t *testing.T) {
 	assert := assert.New(t)
 
 	client := &mockDeleteUserClient{}
-	client.deleteUser.err = sirius.ClientError("problem")
+	client.deleteUser.err = sirius.ValidationError{
+		Errors: sirius.ValidationErrors{
+			"something": {"": "something"},
+		},
+	}
 	template := &mockTemplate{}
 
 	w := httptest.NewRecorder()
@@ -176,8 +180,8 @@ func TestPostDeleteUserClientError(t *testing.T) {
 		Path: "/delete-user/123",
 		User: client.user.data,
 		Errors: sirius.ValidationErrors{
-			"": {
-				"": "problem",
+			"something": {
+				"": "something",
 			},
 		},
 	}, template.lastVars)

--- a/internal/server/edit_user.go
+++ b/internal/server/edit_user.go
@@ -69,12 +69,8 @@ func editUser(client EditUserClient, tmpl Template) Handler {
 			}
 			err := client.EditUser(ctx, vars.User)
 
-			if _, ok := err.(sirius.ClientError); ok {
-				vars.Errors = sirius.ValidationErrors{
-					"firstname": {
-						"": err.Error(),
-					},
-				}
+			if e, ok := err.(sirius.ValidationError); ok {
+				vars.Errors = e.Errors
 
 				w.WriteHeader(http.StatusBadRequest)
 				return tmpl.ExecuteTemplate(w, "page", vars)

--- a/internal/server/edit_user_test.go
+++ b/internal/server/edit_user_test.go
@@ -167,11 +167,15 @@ func TestPostEditUser(t *testing.T) {
 	}, template.lastVars)
 }
 
-func TestPostEditUserClientError(t *testing.T) {
+func TestPostEditUserValidationError(t *testing.T) {
 	assert := assert.New(t)
 
 	client := &mockEditUserClient{}
-	client.editUser.err = sirius.ClientError("something")
+	client.editUser.err = sirius.ValidationError{
+		Errors: sirius.ValidationErrors{
+			"firstname": {"": "something"},
+		},
+	}
 	template := &mockTemplate{}
 
 	w := httptest.NewRecorder()

--- a/internal/sirius/add_user.go
+++ b/internal/sirius/add_user.go
@@ -25,7 +25,7 @@ func (c *Client) AddUser(ctx Context, email, firstName, lastName, organisation s
 		return err
 	}
 
-	req, err := c.newRequest(ctx, http.MethodPost, "/auth/user", &body)
+	req, err := c.newRequest(ctx, http.MethodPost, "/api/v1/users", &body)
 	if err != nil {
 		return err
 	}
@@ -43,10 +43,13 @@ func (c *Client) AddUser(ctx Context, email, firstName, lastName, organisation s
 
 	if resp.StatusCode != http.StatusCreated {
 		var v struct {
-			ErrorMessages ValidationErrors `json:"errorMessages"`
+			ValidationErrors ValidationErrors `json:"validation_errors"`
 		}
+
 		if err := json.NewDecoder(resp.Body).Decode(&v); err == nil {
-			return ValidationError{Errors: v.ErrorMessages}
+			return ValidationError{
+				Errors: v.ValidationErrors,
+			}
 		}
 
 		return newStatusError(resp)

--- a/internal/sirius/add_user_test.go
+++ b/internal/sirius/add_user_test.go
@@ -15,7 +15,7 @@ type addUserBadRequestResponse struct {
 		Email *struct {
 			EmailAddressLengthExceeded string `json:"emailAddressLengthExceeded" pact:"example=The input is more than 255 characters long"`
 		} `json:"email"`
-	} `json:"errorMessages"`
+	} `json:"validation_errors"`
 }
 
 func TestAddUser(t *testing.T) {
@@ -48,7 +48,7 @@ func TestAddUser(t *testing.T) {
 					UponReceiving("A request to add a new user").
 					WithRequest(dsl.Request{
 						Method: http.MethodPost,
-						Path:   dsl.String("/auth/user"),
+						Path:   dsl.String("/api/v1/users"),
 						Headers: dsl.MapMatcher{
 							"Content-Type": dsl.String("application/json"),
 						},
@@ -78,7 +78,7 @@ func TestAddUser(t *testing.T) {
 					UponReceiving("A request to add a new user errors").
 					WithRequest(dsl.Request{
 						Method: http.MethodPost,
-						Path:   dsl.String("/auth/user"),
+						Path:   dsl.String("/api/v1/users"),
 						Headers: dsl.MapMatcher{
 							"Content-Type": dsl.String("application/json"),
 						},
@@ -133,7 +133,7 @@ func TestAddUserStatusError(t *testing.T) {
 	err := client.AddUser(Context{Context: context.Background()}, "", "", "", "", nil)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusTeapot,
-		URL:    s.URL + "/auth/user",
+		URL:    s.URL + "/api/v1/users",
 		Method: http.MethodPost,
 	}, err)
 }

--- a/internal/sirius/delete_user.go
+++ b/internal/sirius/delete_user.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (c *Client) DeleteUser(ctx Context, userID int) error {
-	req, err := c.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/auth/user/%d", userID), nil)
+	req, err := c.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/users/%d", userID), nil)
 	if err != nil {
 		return err
 	}

--- a/internal/sirius/delete_user_test.go
+++ b/internal/sirius/delete_user_test.go
@@ -39,7 +39,7 @@ func TestDeleteUser(t *testing.T) {
 					UponReceiving("A request to delete the user").
 					WithRequest(dsl.Request{
 						Method: http.MethodDelete,
-						Path:   dsl.String("/auth/user/123"),
+						Path:   dsl.String("/api/v1/users/123"),
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -87,7 +87,7 @@ func TestDeleteUserStatusError(t *testing.T) {
 	err := client.DeleteUser(Context{Context: context.Background()}, 123)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusTeapot,
-		URL:    s.URL + "/auth/user/123",
+		URL:    s.URL + "/api/v1/users/123",
 		Method: http.MethodDelete,
 	}, err)
 }

--- a/internal/sirius/edit_user.go
+++ b/internal/sirius/edit_user.go
@@ -30,7 +30,7 @@ func (c *Client) EditUser(ctx Context, user AuthUser) error {
 		return err
 	}
 
-	requestURL := fmt.Sprintf("/auth/user/%d", user.ID)
+	requestURL := fmt.Sprintf("/api/v1/users/%d", user.ID)
 
 	req, err := c.newRequest(ctx, http.MethodPut, requestURL, &body)
 	if err != nil {
@@ -50,11 +50,13 @@ func (c *Client) EditUser(ctx Context, user AuthUser) error {
 
 	if resp.StatusCode != http.StatusOK {
 		var v struct {
-			Message string `json:"message"`
+			ValidationErrors ValidationErrors `json:"validation_errors"`
 		}
 
 		if err := json.NewDecoder(resp.Body).Decode(&v); err == nil {
-			return ClientError(v.Message)
+			return ValidationError{
+				Errors: v.ValidationErrors,
+			}
 		}
 
 		return newStatusError(resp)

--- a/internal/sirius/edit_user_test.go
+++ b/internal/sirius/edit_user_test.go
@@ -11,7 +11,11 @@ import (
 )
 
 type editUserErrorsResponse struct {
-	Message string `json:"message" pact:"example=oops"`
+	Errors *struct {
+		Firstname *struct {
+			TooLong string `json:"stringLengthTooLong" pact:"example=First name must be 255 characters or fewer"`
+		} `json:"firstname"`
+	} `json:"validation_errors"`
 }
 
 func TestEditUser(t *testing.T) {
@@ -45,11 +49,14 @@ func TestEditUser(t *testing.T) {
 			setup: func() {
 				pact.
 					AddInteraction().
-					Given("A user").
+					Given("User exists").
 					UponReceiving("A request to edit the user").
 					WithRequest(dsl.Request{
 						Method: http.MethodPut,
-						Path:   dsl.String("/auth/user/123"),
+						Path:   dsl.String("/api/v1/users/123"),
+						Headers: dsl.MapMatcher{
+							"Content-Type": dsl.String("application/json"),
+						},
 						Body: map[string]interface{}{
 							"id":        123,
 							"email":     "c@opgtest.com",
@@ -73,11 +80,14 @@ func TestEditUser(t *testing.T) {
 			setup: func() {
 				pact.
 					AddInteraction().
-					Given("A user").
+					Given("User exists").
 					UponReceiving("A request to edit the user errors on validation").
 					WithRequest(dsl.Request{
 						Method: http.MethodPut,
-						Path:   dsl.String("/auth/user/123"),
+						Path:   dsl.String("/api/v1/users/123"),
+						Headers: dsl.MapMatcher{
+							"Content-Type": dsl.String("application/json"),
+						},
 						Body: map[string]interface{}{
 							"id":        123,
 							"firstname": "grehjreghjerghjerghjgerhjegrhjgrehgrehjgjherbhjgergrehjreghjerghjerghjgerhjegrhjgrehgrehjgjherbhjgergrehjreghjerghjerghjgerhjegrhjgrehgrehjgjherbhjgergrehjreghjerghjerghjgerhjegrhjgrehgrehjgjherbhjgergrehjreghjerghjerghjgerhjegrhjgrehgrehjgjherbhjgergrehjreghjerghjerghjgerhjegrhjgrehgrehjgjherbhjger",
@@ -91,7 +101,13 @@ func TestEditUser(t *testing.T) {
 						Body:   dsl.Match(editUserErrorsResponse{}),
 					})
 			},
-			expectedError: ClientError("oops"),
+			expectedError: ValidationError{
+				Errors: ValidationErrors{
+					"firstname": {
+						"stringLengthTooLong": "First name must be 255 characters or fewer",
+					},
+				},
+			},
 		},
 	}
 
@@ -120,7 +136,7 @@ func TestEditUserStatusError(t *testing.T) {
 	err := client.EditUser(Context{Context: context.Background()}, AuthUser{ID: 123})
 	assert.Equal(t, StatusError{
 		Code:   http.StatusTeapot,
-		URL:    s.URL + "/auth/user/123",
+		URL:    s.URL + "/api/v1/users/123",
 		Method: http.MethodPut,
 	}, err)
 }

--- a/internal/sirius/user.go
+++ b/internal/sirius/user.go
@@ -26,7 +26,7 @@ type authUserResponse struct {
 }
 
 func (c *Client) User(ctx Context, id int) (AuthUser, error) {
-	req, err := c.newRequest(ctx, http.MethodGet, fmt.Sprintf("/auth/user/%d", id), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/users/%d", id), nil)
 	if err != nil {
 		return AuthUser{}, err
 	}

--- a/internal/sirius/user_test.go
+++ b/internal/sirius/user_test.go
@@ -46,7 +46,7 @@ func TestUser(t *testing.T) {
 					UponReceiving("A request for the user").
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
-						Path:   dsl.String("/auth/user/123"),
+						Path:   dsl.String("/api/v1/users/123"),
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
@@ -101,7 +101,7 @@ func TestUserStatusError(t *testing.T) {
 	_, err := client.User(Context{Context: context.Background()}, 123)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusTeapot,
-		URL:    s.URL + "/auth/user/123",
+		URL:    s.URL + "/api/v1/users/123",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/web/template/edit-user.gotmpl
+++ b/web/template/edit-user.gotmpl
@@ -38,7 +38,7 @@
       <form class="form" method="post">
         <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}" />
 
-        <div class="govuk-form-group">
+        <div class="govuk-form-group {{ if .Errors.email }}govuk-form-group--error{{ end }}">
           <label class="govuk-label" for="f-email">Email address</label>
           {{ range .Errors.email }}
             <p class="govuk-error-message">


### PR DESCRIPTION
Rather than using the `/auth/*` endpoints in the frontend container (which merge API+Membrane requests), use the API endpoints directly and ignore Membrane.

Fixes VEGA-1685 #patch