### PR TITLE
Ignore gosec false positives

### DIFF
--- a/internal/sirius/add_team.go
+++ b/internal/sirius/add_team.go
@@ -35,7 +35,7 @@ func (c *Client) AddTeam(ctx Context, name, teamType, phone, email string) (int,
 	if err != nil {
 		return 0, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return 0, ErrUnauthorized

--- a/internal/sirius/add_user.go
+++ b/internal/sirius/add_user.go
@@ -35,7 +35,7 @@ func (c *Client) AddUser(ctx Context, email, firstName, lastName, organisation s
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return ErrUnauthorized

--- a/internal/sirius/delete_team.go
+++ b/internal/sirius/delete_team.go
@@ -16,7 +16,7 @@ func (c *Client) DeleteTeam(ctx Context, teamID int) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return ErrUnauthorized

--- a/internal/sirius/delete_user.go
+++ b/internal/sirius/delete_user.go
@@ -16,7 +16,7 @@ func (c *Client) DeleteUser(ctx Context, userID int) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return ErrUnauthorized

--- a/internal/sirius/edit_my_details.go
+++ b/internal/sirius/edit_my_details.go
@@ -26,7 +26,7 @@ func (c *Client) EditMyDetails(ctx Context, id int, phoneNumber string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return ErrUnauthorized

--- a/internal/sirius/edit_random_review_settings.go
+++ b/internal/sirius/edit_random_review_settings.go
@@ -31,7 +31,7 @@ func (c *Client) EditRandomReviewSettings(ctx Context, reviewSettings EditRandom
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return ErrUnauthorized

--- a/internal/sirius/edit_team.go
+++ b/internal/sirius/edit_team.go
@@ -46,7 +46,7 @@ func (c *Client) EditTeam(ctx Context, team Team) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return ErrUnauthorized

--- a/internal/sirius/edit_user.go
+++ b/internal/sirius/edit_user.go
@@ -42,7 +42,7 @@ func (c *Client) EditUser(ctx Context, user AuthUser) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return ErrUnauthorized

--- a/internal/sirius/my_details.go
+++ b/internal/sirius/my_details.go
@@ -35,7 +35,7 @@ func (c *Client) MyDetails(ctx Context) (MyDetails, error) {
 	if err != nil {
 		return v, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return v, ErrUnauthorized

--- a/internal/sirius/my_permissions.go
+++ b/internal/sirius/my_permissions.go
@@ -31,7 +31,7 @@ func (c *Client) MyPermissions(ctx Context) (PermissionSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return nil, ErrUnauthorized

--- a/internal/sirius/random_reviews.go
+++ b/internal/sirius/random_reviews.go
@@ -24,7 +24,7 @@ func (c *Client) RandomReviews(ctx Context) (RandomReviews, error) {
 	if err != nil {
 		return data, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return data, ErrUnauthorized

--- a/internal/sirius/roles.go
+++ b/internal/sirius/roles.go
@@ -18,7 +18,7 @@ func (c *Client) Roles(ctx Context) ([]string, error) {
 	if err != nil {
 		return v, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return v, ErrUnauthorized

--- a/internal/sirius/search_users.go
+++ b/internal/sirius/search_users.go
@@ -51,7 +51,7 @@ func (c *Client) SearchUsers(ctx Context, search string) ([]User, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return nil, ErrUnauthorized

--- a/internal/sirius/team.go
+++ b/internal/sirius/team.go
@@ -16,7 +16,7 @@ func (c *Client) Team(ctx Context, id int) (Team, error) {
 	if err != nil {
 		return Team{}, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return Team{}, ErrUnauthorized

--- a/internal/sirius/team_types.go
+++ b/internal/sirius/team_types.go
@@ -24,7 +24,7 @@ func (c *Client) TeamTypes(ctx Context) ([]RefDataTeamType, error) {
 	if err != nil {
 		return v.Data, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return v.Data, ErrUnauthorized

--- a/internal/sirius/teams.go
+++ b/internal/sirius/teams.go
@@ -47,7 +47,7 @@ func (c *Client) Teams(ctx Context) ([]Team, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return nil, ErrUnauthorized

--- a/internal/sirius/user.go
+++ b/internal/sirius/user.go
@@ -35,7 +35,7 @@ func (c *Client) User(ctx Context, id int) (AuthUser, error) {
 	if err != nil {
 		return AuthUser{}, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return AuthUser{}, ErrUnauthorized


### PR DESCRIPTION
We don't care about errors when closing the body of an API request

Fixes VEGA-1706 #patch