### PR TITLE
Ensure user retains hidden roles when edited

### DIFF
--- a/web/template/edit-user.gotmpl
+++ b/web/template/edit-user.gotmpl
@@ -130,6 +130,9 @@
                   </div>
                 {{ end }}
               {{ end }}
+              {{ range $i, $e := .HiddenRoles }}
+                <input id="f-roles-hidden-{{ $i }}" name="roles" type="hidden" value="{{ $e }}" checked>
+              {{ end }}
             </div>
           </fieldset>
         </div>


### PR DESCRIPTION
If the user has any hidden roles (i.e. in `user.roles` but not shown in `/api/v1/roles`), add them as hidden form items so that they're not lost when the user is edited.

Involved changing a few tests that already referred to hidden roles when they should have been using "real" ones.

For VEGA-1765 #patch