### PR TITLE
Upgrade govuk-frontend and moj-frontend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,8 @@ jobs:
 
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: test-results/test-coverage.txt
           fail_ci_if_error: true

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "license": "MIT",
   "scripts": {
     "build": "yarn build:js && yarn build:css && yarn build:assets",
-    "build:js": "esbuild --bundle web/assets/main.js --minify --outfile=web/static/javascript/all.js --sourcemap --resolve-extensions=.mjs,.js",
+    "build:js": "esbuild --bundle web/assets/load-classes.js web/assets/main.js --minify --outdir=web/static/javascript --sourcemap --resolve-extensions=.mjs,.js",
     "build:css": "sass --load-path . --style compressed web/assets/main.scss web/static/stylesheets/all.css",
-    "build:assets": "mkdir -p web/static/assets/images web/static/assets/fonts && cp node_modules/govuk-frontend/govuk/assets/images/* node_modules/@ministryofjustice/frontend/moj/assets/images/* web/static/assets/images && cp node_modules/govuk-frontend/govuk/assets/fonts/* web/static/assets/fonts",
+    "build:assets": "mkdir -p web/static/assets/images web/static/assets/fonts && cp node_modules/govuk-frontend/dist/govuk/assets/images/* node_modules/@ministryofjustice/frontend/moj/assets/images/* web/static/assets/images && cp node_modules/govuk-frontend/dist/govuk/assets/fonts/* web/static/assets/fonts",
     "clean": "rm -rf web/static",
     "cypress": "cypress open",
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@ministryofjustice/frontend": "1.8.1",
-    "govuk-frontend": "^4.4.0"
+    "@ministryofjustice/frontend": "^2.1.0",
+    "govuk-frontend": "^5.0.0"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^6.0.0",

--- a/web/assets/load-classes.js
+++ b/web/assets/load-classes.js
@@ -1,0 +1,1 @@
+document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -1,7 +1,4 @@
 import * as GOVUKFrontend from "govuk-frontend";
 import MOJFrontend from "@ministryofjustice/frontend/moj/all.js";
 
-document.body.className = document.body.className
-  ? document.body.className + " js-enabled"
-  : "js-enabled";
 GOVUKFrontend.initAll();

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -1,6 +1,6 @@
 $govuk-assets-path: "/admin/assets/";
 
-@import "node_modules/govuk-frontend/govuk/all";
+@import "node_modules/govuk-frontend/dist/govuk/all";
 @import "node_modules/@ministryofjustice/frontend/moj/all";
 
 .govuk-table .link-button {

--- a/web/template/layout/page.gotmpl
+++ b/web/template/layout/page.gotmpl
@@ -10,16 +10,14 @@
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
       <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ prefix "/assets/images/favicon.ico" }}" type="image/x-icon">
-      <link rel="mask-icon" href="{{ prefix "/assets/images/govuk-mask-icon.svg" }}" color="blue">
-      <link rel="apple-touch-icon" sizes="180x180" href="{{ prefix "/assets/images/govuk-apple-touch-icon-180x180.png" }}">
-      <link rel="apple-touch-icon" sizes="167x167" href="{{ prefix "/assets/images/govuk-apple-touch-icon-167x167.png" }}">
-      <link rel="apple-touch-icon" sizes="152x152" href="{{ prefix "/assets/images/govuk-apple-touch-icon-152x152.png" }}">
-      <link rel="apple-touch-icon" href="{{ prefix "/assets/images/govuk-apple-touch-icon.png" }}">
+      <link rel="icon" sizes="any" href="{{ prefix "/assets/images/favicon.svg" }}" type="image/svg+xml">
+      <link rel="mask-icon" href="{{ prefix "/assets/images/govuk-icon-mask.svg" }}" color="blue">
+      <link rel="apple-touch-icon" href="{{ prefix "/assets/images/govuk-icon-180.png" }}">
 
       <link href="{{ prefix "/stylesheets/all.css" }}" rel="stylesheet">
     </head>
 
-    <body class="govuk-template__body app-body-class" data-test="My value" data-other="report:details">
+    <body class="govuk-template__body app-body-class">
       <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 
       {{ template "header" . }}
@@ -35,7 +33,8 @@
 
       <footer class="govuk-footer" role="contentinfo"> </footer>
 
-      <script src="{{ prefix "/javascript/all.js" }}"></script>
+      <script src="{{ prefix "/javascript/load-classes.js" }}"></script>
+      <script src="{{ prefix "/javascript/main.js" }}" type="module"></script>
     </body>
   </html>
 {{ end }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,12 +203,12 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@ministryofjustice/frontend@1.8.1":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-1.8.1.tgz#6bac39524ba406533d1ce51c55d4c8ff96ad358e"
-  integrity sha512-HNl8XXbNje/NtQRlGM57CTLlAGBTW+ziGTBkxXHDn7VauKNz418PnErDlKRWeaHIyc6V9twI5EbOj4lFCsvasw==
+"@ministryofjustice/frontend@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-2.1.0.tgz#6abf032263f243bf9a05dade198d4a0b5ecd1570"
+  integrity sha512-LekTR097OsFku0+sREn7gR3G7UvH7jATw40PvZH4mKtnE8hyyw0gDrCSvFYsRS4kPLDsoFqZ5l0Y3CZE9f364g==
   dependencies:
-    govuk-frontend "^3.0.0 || ^4.0.0"
+    govuk-frontend "^5.0.0"
     moment "^2.27.0"
 
 "@types/eslint-scope@^3.7.3":
@@ -1161,10 +1161,10 @@ global-dirs@^3.0.0:
   dependencies:
     ini "2.0.0"
 
-"govuk-frontend@^3.0.0 || ^4.0.0", govuk-frontend@^4.4.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.7.0.tgz#69950b6c2e69f435ffe9aa60d8dee232dac977de"
-  integrity sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==
+govuk-frontend@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.0.0.tgz#c08a4d1115fb31eb39b6d19979c627f816185dd7"
+  integrity sha512-3WSfvQ+3kw/q/m8jrq/t8XnMUA8D2r0uhGyZaDbIh1gWTJBQzJBHbHiKYI9nc9ixIXdCFsc9RozkgEm57a795g==
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.11"


### PR DESCRIPTION
- Update path references to include `/dist`
- Move body-class-setting into separate file (it needs to be done before we import govuk-frontend and we block inline scripts)
- Update icon paths

For VEGA-2202 #minor