### PR TITLE
Handle cancelled requests

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
@@ -169,6 +171,11 @@ func errorHandler(logger Logger, client ErrorHandlerClient, tmplError Template, 
 			}
 
 			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					w.WriteHeader(499)
+					return
+				}
+
 				if err == sirius.ErrUnauthorized {
 					http.Redirect(w, r, fmt.Sprintf("%s/auth?redirect=%s", siriusURL, url.QueryEscape(prefix+r.URL.Path)), http.StatusFound)
 					return


### PR DESCRIPTION
If the request is cancelled, issue a 499 response and return immediately. Don't render a template, as it will never be shown. Don't log the error, as we know what it is and have handled it.

#minor