### PR TITLE
Upgrade musl to non-vulnerable version

### DIFF
--- a/docker/sirius-user-management/Dockerfile
+++ b/docker/sirius-user-management/Dockerfile
@@ -35,7 +35,7 @@ RUN apk --update --no-cache add \
     tzdata \
     && rm -rf /var/cache/apk/*
 
-RUN apk upgrade libcrypto3 libssl3 busybox zlib
+RUN apk upgrade libcrypto3 musl musl-utils zlib
 
 COPY --from=build-env /go/bin/opg-sirius-user-management opg-sirius-user-management
 COPY --from=asset-env /app/web/static web/static


### PR DESCRIPTION
And stop updating libssl3/busybox, since the default version on the image is now the latest.

#patch