### PR TITLE
Upgrade frontend libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@ministryofjustice/frontend": "^8.0.0",
-        "govuk-frontend": "^5.0.0"
+        "@ministryofjustice/frontend": "^9.0.0",
+        "govuk-frontend": "^6.1.0"
       },
       "devDependencies": {
         "@cypress/webpack-preprocessor": "^7.0.0",
@@ -2216,15 +2216,15 @@
       }
     },
     "node_modules/@ministryofjustice/frontend": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-8.0.1.tgz",
-      "integrity": "sha512-IPgCcNe+XKV55I4J/SIoYAkfYp7mmUKjO1igXhzOtcF05+stWPbJuL9QzKORlRUxkwZtQ1jmiY7PZxMQzOXniw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-9.0.0.tgz",
+      "integrity": "sha512-R63EvHq//lONAhpUfZCMfxlUHoysDx5Hc6mi9EEV+sfVGm2spGV52PJAkYCYAc3bhTaTiJDtEM+PXgJm0iTWvQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       },
       "peerDependencies": {
-        "govuk-frontend": "^5.11.2",
+        "govuk-frontend": "^6.0.0",
         "moment": "2.30.1"
       }
     },
@@ -4342,9 +4342,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.14.0.tgz",
-      "integrity": "sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.1.0.tgz",
+      "integrity": "sha512-sqivexZFa82LiDIDVMItsUlqEXE/wEUWWBqzEoxHvUFLBH7bY0C8lVrj1qsDThSnj5JEUMS7isBAbKnfQ5Qp6g==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@ministryofjustice/frontend": "^8.0.0",
-    "govuk-frontend": "^5.0.0"
+    "@ministryofjustice/frontend": "^9.0.0",
+    "govuk-frontend": "^6.1.0"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^7.0.0",

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -1,12 +1,12 @@
 $govuk-assets-path: "/admin/assets/";
 
-@import "node_modules/govuk-frontend/dist/govuk/all";
+@import "node_modules/govuk-frontend/dist/govuk";
 @import "node_modules/@ministryofjustice/frontend/moj/all";
 
 .govuk-table .link-button {
   @include govuk-link-common;
   @include govuk-link-style-default;
-  color: $govuk-link-colour;
+  color: govuk-functional-colour(link);
   text-decoration: underline;
   margin-bottom: 0;
   padding: 0;
@@ -32,8 +32,8 @@ $govuk-assets-path: "/admin/assets/";
 }
 
 #sirius-title {
-    float: right;
-    width: 60%;
+  float: right;
+  width: 60%;
 }
 
 #header-logo {
@@ -41,7 +41,8 @@ $govuk-assets-path: "/admin/assets/";
 }
 
 .app-table-align-middle {
-  & th, & td {
+  & th,
+  & td {
     vertical-align: middle;
   }
 }

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -46,7 +46,3 @@ $govuk-assets-path: "/admin/assets/";
     vertical-align: middle;
   }
 }
-
-#footer-background {
-  background: #f4f8fb;
-}

--- a/web/template/layout/feedback-header.gotmpl
+++ b/web/template/layout/feedback-header.gotmpl
@@ -8,7 +8,7 @@
                  </svg>
                  <a class="moj-header__link moj-header__link--organisation-name" href="#">OPG</a>
            </div>
-           <div id="sirius-title" class="govuk-header__content">
+           <div id="sirius-title">
                 <a href="/" class="moj-header__link moj-header__link--service-name">
                    Sirius - Supervision
                 </a>

--- a/web/template/layout/footer.gotmpl
+++ b/web/template/layout/footer.gotmpl
@@ -1,5 +1,5 @@
 {{ define "footer" }}
-    <footer id="footer-background" class="govuk-footer" role="contentinfo">
+    <footer class="govuk-footer" role="contentinfo">
         <div class="govuk-width-container">
             <svg focusable="false" role="presentation" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 60" height="30" width="32" fill="currentcolor" class="govuk-footer__crown" style=" margin-left: 10px;">    <g>
                     <circle cx="20" cy="17.6" r="3.7"></circle>


### PR DESCRIPTION
Upgrade `govuk-frontend` to v6, and `@ministryofjustice/frontend` to v9.

Update imports.

Replace `$govuk-link-colour` with `govuk-functional-colour(link)`

Remove `.govuk-header__content` that no longer exists (and didn't do anything useful)

For VEGA-3810 #patch